### PR TITLE
Fix install failure on macOS

### DIFF
--- a/bindings/perl/Makefile.am
+++ b/bindings/perl/Makefile.am
@@ -108,7 +108,7 @@ libpath_mangled: ${nodist_perlautogetdata_SCRIPTS}
 	touch $@
 
 # Change mangled path into install path again
-install-exec-hook:
+install-exec-hook: install-data-am
 	${INSTALL_NAME_TOOL} -change \
 		${abs_top_builddir}/src/.libs/libgetdata.${GETDATA_IFACE_VERSION}.dylib \
 		${libdir}/libgetdata.${GETDATA_IFACE_VERSION}.dylib \


### PR DESCRIPTION
Currently, `make install` fails on macOS because `install_name_tool` is
called on `GetData.bundle` inside the install prefix before it has been
installed.

Let's fix that by making sure `GetData.bundle` has been installed before
trying to look for it inside the install prefix.

I don't really grok Automake, so I don't know if this is the right fix
for this. However, it seems to fix the failure we were seeing earlier.

Closes #4
Closes #5