### PR TITLE
Fix PYTHON_VERSION detection for python 3.10 and higher

### DIFF
--- a/m4/python.m4
+++ b/m4/python.m4
@@ -161,7 +161,7 @@ AC_MSG_CHECKING([if we're using a Python3 interpreter])
 AC_MSG_RESULT([$have_python3])
 
 AC_MSG_CHECKING([$PYTHON version])
-PYTHON_VERSION=`$PYTHON -c "import sys; print (sys.version[[:3]])"`
+PYTHON_VERSION=`$PYTHON -c "import sys; print('{v[[0]]}.{v[[1]]}'.format(v=sys.version_info))"`
 AC_MSG_RESULT([$PYTHON_VERSION])
 AC_SUBST([PYTHON_VERSION])
 


### PR DESCRIPTION
Fix m4 line detecting the PYTHON_VERSION

Formerly used first 3 characters of `sys.version` string, but this breaks for 2-digit minor versions (eg 3.10 and up)
Replace with string containing values from `sys.version_info`