### PR TITLE
Fix `-D_FILE_OFFSET_BITS=64 -D_TIME_BITS=64` on 32-bit archs

### DIFF
--- a/src/flimits.c
+++ b/src/flimits.c
@@ -130,6 +130,7 @@ off64_t gd_frameoffset64(DIRFILE* D, int fragment)
   return D->fragment[fragment].frame_offset;
 }
 
+#if !(defined _FILE_OFFSET_BITS && _FILE_OFFSET_BITS == 64)
 /* 32(ish)-bit wrappers for the 64-bit versions, when needed */
 int gd_alter_frameoffset(DIRFILE* D, off_t offset, int fragment, int move)
 {
@@ -140,6 +141,7 @@ off_t gd_frameoffset(DIRFILE* D, int fragment) gd_nothrow
 {
   return gd_frameoffset64(D, fragment);
 }
+#endif
 
 off64_t _GD_GetEOF(DIRFILE *restrict D, gd_entry_t *restrict E,
     const char *restrict parent, int *restrict is_index)
@@ -340,11 +342,13 @@ off64_t gd_eof64(DIRFILE* D, const char *field_code)
   return ns;
 }
 
+#if !(defined _FILE_OFFSET_BITS && _FILE_OFFSET_BITS == 64)
 /* 32(ish)-bit wrapper for the 64-bit version, when needed */
 off_t gd_eof(DIRFILE* D, const char *field_code)
 {
   return (off_t)gd_eof64(D, field_code);
 }
+#endif
 
 static off64_t _GD_GetBOF(DIRFILE *restrict D, gd_entry_t *restrict E,
     const char *restrict parent, unsigned int *restrict spf,
@@ -510,10 +514,12 @@ off64_t gd_bof64(DIRFILE* D, const char *field_code) gd_nothrow
   return bof;
 }
 
+#if !(defined _FILE_OFFSET_BITS && _FILE_OFFSET_BITS == 64)
 /* 32(ish)-bit wrapper for the 64-bit version, when needed */
 off_t gd_bof(DIRFILE* D, const char *field_code) gd_nothrow
 {
   return (off_t)gd_bof64(D, field_code);
 }
+#endif
 /* vim: ts=2 sw=2 et tw=80
 */

--- a/src/getdata.c
+++ b/src/getdata.c
@@ -2051,6 +2051,7 @@ size_t gd_getdata64(DIRFILE* D, const char *field_code, off64_t first_frame,
   return n_read;
 }
 
+#if !(defined _FILE_OFFSET_BITS && _FILE_OFFSET_BITS == 64)
 /* 32(ish)-bit wrapper for the 64-bit version, when needed */
 size_t gd_getdata(DIRFILE* D, const char *field_code, off_t first_frame,
     off_t first_samp, size_t num_frames, size_t num_samp,
@@ -2059,5 +2060,6 @@ size_t gd_getdata(DIRFILE* D, const char *field_code, off_t first_frame,
   return gd_getdata64(D, field_code, first_frame, first_samp, num_frames,
       num_samp, return_type, data_out);
 }
+#endif
 /* vim: ts=2 sw=2 et tw=80
 */

--- a/src/index.c
+++ b/src/index.c
@@ -255,6 +255,7 @@ double gd_framenum_subset64(DIRFILE* D, const char* field_code, double value,
   return frame;
 }
 
+#if !(defined _FILE_OFFSET_BITS && _FILE_OFFSET_BITS == 64)
 double gd_framenum_subset(DIRFILE* D, const char* field_code, double value,
     off_t field_start, off_t field_end)
 {
@@ -269,6 +270,7 @@ double gd_framenum_subset(DIRFILE* D, const char* field_code, double value,
   dreturn("%.15g", frame);
   return frame;
 }
+#endif
 
 double gd_framenum(DIRFILE* D, const char* field_code, double value)
 {

--- a/src/iopos.c
+++ b/src/iopos.c
@@ -136,10 +136,12 @@ off64_t gd_tell64(DIRFILE *D, const char *field_code) gd_nothrow
   return pos;
 }
 
+#if !(defined _FILE_OFFSET_BITS && _FILE_OFFSET_BITS == 64)
 off_t gd_tell(DIRFILE *D, const char *field_code) gd_nothrow
 {
   return (off_t)gd_tell64(D, field_code);
 }
+#endif
 
 off64_t _GD_DoSeek(DIRFILE *D, gd_entry_t *E, const struct encoding_t *enc,
     off64_t offset, unsigned int mode)
@@ -410,10 +412,12 @@ off64_t gd_seek64(DIRFILE *D, const char *field_code, off64_t frame_num,
   return pos;
 }
 
+#if !(defined _FILE_OFFSET_BITS && _FILE_OFFSET_BITS == 64)
 off_t gd_seek(DIRFILE *D, const char *field_code, off_t frame_num,
     off_t sample_num, int whence)
 {
   return (off_t)gd_seek64(D, field_code, frame_num, sample_num, whence);
 }
+#endif
 /* vim: ts=2 sw=2 et tw=80
 */

--- a/src/nframes.c
+++ b/src/nframes.c
@@ -73,10 +73,12 @@ off64_t gd_nframes64(DIRFILE* D)
   return nf;
 }
 
+#if !(defined _FILE_OFFSET_BITS && _FILE_OFFSET_BITS == 64)
 /* 32(ish)-bit wrapper for the 64-bit version, when needed */
 off_t gd_nframes(DIRFILE* D)
 {
   return (off_t)gd_nframes64(D);
 }
+#endif
 /* vim: ts=2 sw=2 et tw=80
 */

--- a/src/putdata.c
+++ b/src/putdata.c
@@ -816,6 +816,7 @@ size_t gd_putdata64(DIRFILE* D, const char *field_code, off64_t first_frame,
   return n_wrote;
 }
 
+#if !(defined _FILE_OFFSET_BITS && _FILE_OFFSET_BITS == 64)
 /* 32(ish)-bit wrapper for the 64-bit version, when needed */
 size_t gd_putdata(DIRFILE* D, const char *field_code, off_t first_frame,
     off_t first_samp, size_t num_frames, size_t num_samp, gd_type_t data_type,
@@ -824,5 +825,6 @@ size_t gd_putdata(DIRFILE* D, const char *field_code, off_t first_frame,
   return gd_putdata64(D, field_code, first_frame, first_samp, num_frames,
       num_samp, data_type, data_in);
 }
+#endif
 /* vim: ts=2 sw=2 et
 */


### PR DESCRIPTION
On Debian, we have begun to compile 32-bit architectures (except i386) with
`-D_FILE_OFFSET_BITS=64 -D_TIME_BITS=64` which triggers build failures fixed
by this patch.

https://wiki.debian.org/ReleaseGoals/64bit-time

```
./getdata.h:1094:30: error: redefinition of ‘gd_alter_frameoffset64’
 1094 | #define gd_alter_frameoffset gd_alter_frameoffset64
      |                              ^~~~~~~~~~~~~~~~~~~~~~
../../src/flimits.c:134:5: note: in expansion of macro ‘gd_alter_frameoffset’
  134 | int gd_alter_frameoffset(DIRFILE* D, off_t offset, int fragment, int move)
      |     ^~~~~~~~~~~~~~~~~~~~
../../src/flimits.c:93:5: note: previous definition of ‘gd_alter_frameoffset64’ with type ‘int(DIRFILE *, off64_t,  int,  int)’ {aka ‘int(struct gd_dirfile_ *, long long int,  int,  int)’}
   93 | int gd_alter_frameoffset64(DIRFILE* D, off64_t offset, int fragment, int move)
      |     ^~~~~~~~~~~~~~~~~~~~~~
./getdata.h:1098:24: error: redefinition of ‘gd_frameoffset64’
 1098 | #define gd_frameoffset gd_frameoffset64
      |                        ^~~~~~~~~~~~~~~~
../../src/flimits.c:139:7: note: in expansion of macro ‘gd_frameoffset’
  139 | off_t gd_frameoffset(DIRFILE* D, int fragment) gd_nothrow
      |       ^~~~~~~~~~~~~~
../../src/flimits.c:120:9: note: previous definition of ‘gd_frameoffset64’ with type ‘off64_t(DIRFILE *, int)’ {aka ‘long long int(struct gd_dirfile_ *, int)’}
  120 | off64_t gd_frameoffset64(DIRFILE* D, int fragment)
      |         ^~~~~~~~~~~~~~~~
./getdata.h:1101:16: error: redefinition of ‘gd_eof64’
 1101 | #define gd_eof gd_eof64
      |                ^~~~~~~~
../../src/flimits.c:344:7: note: in expansion of macro ‘gd_eof’
  344 | off_t gd_eof(DIRFILE* D, const char *field_code)
      |       ^~~~~~
../../src/flimits.c:318:9: note: previous definition of ‘gd_eof64’ with type ‘off64_t(DIRFILE *, const char *)’ {aka ‘long long int(struct gd_dirfile_ *, const char *)’}
  318 | off64_t gd_eof64(DIRFILE* D, const char *field_code)
      |         ^~~~~~~~
./getdata.h:1100:16: error: redefinition of ‘gd_bof64’
 1100 | #define gd_bof gd_bof64
      |                ^~~~~~~~
../../src/flimits.c:514:7: note: in expansion of macro ‘gd_bof’
  514 | off_t gd_bof(DIRFILE* D, const char *field_code) gd_nothrow
      |       ^~~~~~
../../src/flimits.c:488:9: note: previous definition of ‘gd_bof64’ with type ‘off64_t(DIRFILE *, const char *)’ {aka ‘long long int(struct gd_dirfile_ *, const char *)’}
  488 | off64_t gd_bof64(DIRFILE* D, const char *field_code) gd_nothrow
      |         ^~~~~~~~
```