### PR TITLE
Fix python tests

### DIFF
--- a/bindings/python/Makefile.am
+++ b/bindings/python/Makefile.am
@@ -33,12 +33,8 @@ BUILT_SOURCES = pyconstants.c
 
 EXTRA_DIST = pydirfile.c pygetdata.c pyentry.c gdpy_intern.h pyfragment.c
 
-distutils_path=build/lib.${PYTHON_PLATFORM}-${PYTHON_VERSION}
-pygetdata${PYTHON_OBJECT_SUFFIX}: ${distutils_path}/pygetdata${PYTHON_OBJECT_SUFFIX}
-	cp $< $@
-
-${distutils_path}/pygetdata${PYTHON_OBJECT_SUFFIX}: setup.py ${BUILT_SOURCES} ${EXTRA_DIST}
-	${PYTHON} setup.py build
+pygetdata${PYTHON_OBJECT_SUFFIX}: setup.py ${BUILT_SOURCES} ${EXTRA_DIST}
+	${PYTHON} setup.py build_ext --inplace
 
 pyconstants.c: ../make_parameters
 	../make_parameters p > $@

--- a/bindings/python/test/big_test.py
+++ b/bindings/python/test/big_test.py
@@ -24,6 +24,7 @@ import re
 import array
 import pygetdata
 import numpy
+import warnings
 
 # These two functions abstractify differences between Python2 and 3.
 def L(n):
@@ -1480,7 +1481,9 @@ CheckNumpy(176,n,numpy.array([9,8,176,176,5,4]))
 
 # 177: gd_carray_len
 try:
-  n = d.carray_len("carray")
+  with warnings.catch_warnings():
+    warnings.simplefilter("ignore")  # carray_len causes DeprecationWarning
+    n = d.carray_len("carray")
 except:
   CheckOK(177)
 

--- a/bindings/python/test/big_test.py
+++ b/bindings/python/test/big_test.py
@@ -2027,7 +2027,7 @@ try:
 except:
   CheckOK(278)
 
-CheckSimple(278,n,['one', 'two', 'three', 'four', 'five', 'six', 'seven'])
+CheckSimple(278,n,[B('one'), B('two'), B('three'), B('four'), B('five'), B('six'), B('seven')])
 
 # 279: gd_get_sarray_slice
 try:
@@ -2035,7 +2035,7 @@ try:
 except:
   CheckOK(279)
 
-CheckSimple(279,n,['three', 'four'])
+CheckSimple(279,n,[B('three'), B('four')])
 
 # 280: gd_sarrays
 try:
@@ -2044,13 +2044,13 @@ except:
   CheckOK(280)
 
 CheckSimple2(280,1,len(n),1)
-CheckSimple2(280,2,n,[("sarray",
-  ['one', 'two', 'three', 'four', 'five', 'six', 'seven'])])
+CheckSimple2(280,2,n,[(B("sarray"),
+  [B('one'), B('two'), B('three'), B('four'), B('five'), B('six'), B('seven')])])
 
 # 281: gd_put_sarray
 try:
   d.put_sarray("sarray",
-      ['eka', 'dvi', 'tri', 'catur', 'panca', 'sas', 'sapta'])
+      [B('eka'), B('dvi'), B('tri'), B('catur'), B('panca'), B('sas'), B('sapta')])
 except:
   CheckOK2(281,1)
 
@@ -2059,7 +2059,7 @@ try:
 except:
   CheckOK2(281,2)
 
-CheckSimple(281,n,['eka', 'dvi', 'tri', 'catur', 'panca', 'sas', 'sapta'])
+CheckSimple(281,n,[B('eka'), B('dvi'), B('tri'), B('catur'), B('panca'), B('sas'), B('sapta')])
 
 # 282: gd_put_sarray_slice
 try:
@@ -2072,7 +2072,7 @@ try:
 except:
   CheckOK2(282,2)
 
-CheckSimple(282,n,['eka', 'dvi', 'asta', 'nava', 'panca', 'sas', 'sapta'])
+CheckSimple(282,n,[B('eka'), B('dvi'), B('asta'), B('nava'), B('panca'), B('sas'), B('sapta')])
 
 # 283: gd_add_sarray
 ent = pygetdata.entry(pygetdata.SARRAY_ENTRY, "new283", 0, (2,))
@@ -2114,8 +2114,8 @@ except:
 
 CheckSimple2(287,1,len(n),2)
 CheckSimple2(287,2,n,[
-  ("msarray", ['eight', 'nine', 'ten', 'eleven', 'twelve']),
-  ("mnew285", ['', ''])])
+  (B("msarray"), [B('eight'), B('nine'), B('ten'), B('eleven'), B('twelve')]),
+  (B("mnew285"), [B(''), B('')])])
 
 # 288: entry (indir) check
 try:
@@ -2125,10 +2125,10 @@ except:
 CheckSimple2(288,1,ent.field_type,pygetdata.INDIR_ENTRY)
 CheckSimple2(288,2,ent.field_type_name,"INDIR_ENTRY")
 CheckSimple2(288,3,ent.fragment,0)
-CheckSimple2(288,4,ent.in_fields,( "data", "carray"))
+CheckSimple2(288,4,ent.in_fields,( B("data"), B("carray")))
 
 # 289: add / entry (indir) check
-ent = pygetdata.entry(pygetdata.INDIR_ENTRY, "new289", 0, ("in1", "in2"))
+ent = pygetdata.entry(pygetdata.INDIR_ENTRY, B("new289"), 0, (B("in1"), B("in2")))
 try:
   d.add(ent)
 except:
@@ -2140,7 +2140,7 @@ except:
   CheckOK2(289,2)
 CheckSimple2(289,1,ent.field_type,pygetdata.INDIR_ENTRY)
 CheckSimple2(289,2,ent.fragment,0)
-CheckSimple2(289,3,ent.in_fields,( "in1", "in2"))
+CheckSimple2(289,3,ent.in_fields,( B("in1"), B("in2")))
 
 # 290: madd / entry (indir) check
 ent = pygetdata.entry(pygetdata.INDIR_ENTRY, "mnew290", 0,
@@ -2156,7 +2156,7 @@ except:
   CheckOK2(290,2)
 CheckSimple2(290,1,ent.field_type,pygetdata.INDIR_ENTRY)
 CheckSimple2(290,2,ent.fragment,0)
-CheckSimple2(290,3,ent.in_fields,( "in3", "in2"))
+CheckSimple2(290,3,ent.in_fields,( B("in3"), B("in2")))
 
 # 292: entry (sindir) check
 try:
@@ -2166,7 +2166,7 @@ except:
 CheckSimple2(292,1,ent.field_type,pygetdata.SINDIR_ENTRY)
 CheckSimple2(292,2,ent.field_type_name,"SINDIR_ENTRY")
 CheckSimple2(292,3,ent.fragment,0)
-CheckSimple2(292,4,ent.in_fields,( "data", "sarray"))
+CheckSimple2(292,4,ent.in_fields,( B("data"), B("sarray")))
 
 # 293: add / entry (dindir) check
 ent = pygetdata.entry(pygetdata.SINDIR_ENTRY, "new293", 0, ("in1", "in2"))
@@ -2181,7 +2181,7 @@ except:
   CheckOK2(293,2)
 CheckSimple2(293,1,ent.field_type,pygetdata.SINDIR_ENTRY)
 CheckSimple2(293,2,ent.fragment,0)
-CheckSimple2(293,3,ent.in_fields,( "in1", "in2"))
+CheckSimple2(293,3,ent.in_fields,( B("in1"), B("in2")))
 
 # 294: madd / entry (sindir) check
 ent = pygetdata.entry(pygetdata.SINDIR_ENTRY, "mnew294", 0,
@@ -2197,14 +2197,14 @@ except:
   CheckOK2(294,2)
 CheckSimple2(294,1,ent.field_type,pygetdata.SINDIR_ENTRY)
 CheckSimple2(294,2,ent.fragment,0)
-CheckSimple2(294,3,ent.in_fields,( "in3", "in2"))
+CheckSimple2(294,3,ent.in_fields,( B("in3"), B("in2")))
 
 # 296: getstrdata
 try:
   n = d.getdata("sindir", num_frames=1)
 except:
   CheckOK(296)
-CheckSimple(296,n,[ "eka", "eka", "eka", "eka", "eka", "eka", "eka", "eka"])
+CheckSimple(296,n,[ B("eka"), B("eka"), B("eka"), B("eka"), B("eka"), B("eka"), B("eka"), B("eka")])
 
 # 302: gd_include_affix check
 try:

--- a/bindings/python/test/big_test.py
+++ b/bindings/python/test/big_test.py
@@ -1882,7 +1882,7 @@ CheckSimple2(231, 5, ent.period, 7)
 
 # 232: gd_strtok check
 try:
-  str = d.strtok("\"test1 test2\" test3\ test4")
+  str = d.strtok("\"test1 test2\" test3\\ test4")
 except:
   CheckOK2(232, 1)
 CheckSimple2(232, 2, str, B("test1 test2"))

--- a/m4/python.m4
+++ b/m4/python.m4
@@ -160,12 +160,12 @@ dnl Python version
 AC_MSG_CHECKING([if we're using a Python3 interpreter])
 AC_MSG_RESULT([$have_python3])
 
-AC_MSG_CHECKING([$PYTHON version])
-PYTHON_VERSION=`$PYTHON -c "import sys; print (sys.version[[:3]])"`
+AC_MSG_CHECKING([Python version])
+PYTHON_VERSION=`$PYTHON -c "import sys; print('{v[[0]]}.{v[[1]]}'.format(v=sys.version_info))"`
 AC_MSG_RESULT([$PYTHON_VERSION])
 AC_SUBST([PYTHON_VERSION])
 
-dnl Python ABI version (which can be different than VERISON in python3)
+dnl Python ABI version (which can be different than VERSION in python3)
 AC_MSG_CHECKING([Python ABI version])
 GD_PYTHON_CONFIGVAR([PYTHON_LDVERSION], [LDVERSION])
 if test "${PYTHON_LDVERSION}" = "None"; then
@@ -188,13 +188,6 @@ AC_MSG_CHECKING([Python LDFLAGS])
 GD_PYTHON_CONFIGVAR([PYTHON_LIBDIR], [LIBDIR])
 PYTHON_LDFLAGS="-L${PYTHON_LIBDIR} -lpython${PYTHON_LDVERSION}"
 AC_MSG_RESULT([$PYTHON_LDFLAGS])
-
-dnl figure out the platform name
-AC_MSG_CHECKING([Python platform name])
-PYTHON_PLATFORM=`$PYTHON -c \
-  "from distutils import util; print (util.get_platform())"`
-AC_MSG_RESULT([$PYTHON_PLATFORM])
-AC_SUBST([PYTHON_PLATFORM])
 
 dnl calculate the extension module directory
 dnl


### PR DESCRIPTION
These commits tidy up a few problems in big_test.py.

The first commit uses the B("") helper to paper over what I think is a string encoding problem that goes all the way back to Python2/Python3. I have only tried this code in Python 3.12, though, so I'm reluctant to assert it wasn't introduced in a more recent python 3.x release.

The other two commits are just clean-ups for warning messages. 