### PR TITLE
Adds vanilla CI/CD build flow using ubuntu-latest

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,7 +20,14 @@ jobs:
     - name: Install build dependencies
       run: |
         sudo apt-get update
-        sudo apt-get install -y build-essential autoconf libpcre2-dev libpython3-dev liblzma-dev wget
+        sudo apt-get install -y             \
+                autoconf                    \
+                build-essential             \
+                liblzma-dev                 \
+                libpcre2-dev                \
+                libpython3-dev              \
+                python3-numpy-dev           \
+                wget
 
     - name: Configure
       run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,34 @@
+name: Build
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+env:
+  CC: gcc-10
+  CXX: g++-10
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Install build dependencies
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y build-essential autoconf libpcre2-dev libpython3-dev liblzma-dev wget
+
+    - name: Configure
+      run: |
+        autoreconf -i
+        ./configure --disable-php
+
+    - name: Build
+      run: make
+
+    - name: Run regression tests
+      run: make check


### PR DESCRIPTION
This build is expected to fail without #11, which fixes the Python regression tests.