### PR TITLE
Build fixes for MacOS

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -18,7 +18,7 @@
 # along with GetData; if not, write to the Free Software Foundation, Inc.,
 # 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 #
-AUTOMAKE_OPTIONS = foreign dist-xz check-news 1.13
+AUTOMAKE_OPTIONS = foreign dist-xz check-news 1.16
 
 EXTRA_DIST = ChangeLog
 

--- a/bindings/perl/Makefile.am
+++ b/bindings/perl/Makefile.am
@@ -103,15 +103,15 @@ nodist_noinst_DATA = libpath_mangled
 # Change, say /usr/local/lib/libgetdata.#.dylib, into .libs/libgetdata.#.dylib
 libpath_mangled: ${nodist_perlautogetdata_SCRIPTS}
 	${INSTALL_NAME_TOOL} -change \
-		${libdir}/libgetdata.${GETDATA_IFACE_VERSION}.dylib \
-		${abs_top_builddir}/src/.libs/libgetdata.${GETDATA_IFACE_VERSION}.dylib $<
+		${libdir}/libgetdata.${GETDATA_MIN_IFACE}.dylib \
+		${abs_top_builddir}/src/.libs/libgetdata.${GETDATA_MIN_IFACE}.dylib $<
 	touch $@
 
 # Change mangled path into install path again
-install-exec-hook:
+install-data-hook:
 	${INSTALL_NAME_TOOL} -change \
-		${abs_top_builddir}/src/.libs/libgetdata.${GETDATA_IFACE_VERSION}.dylib \
-		${libdir}/libgetdata.${GETDATA_IFACE_VERSION}.dylib \
+		${abs_top_builddir}/src/.libs/libgetdata.${GETDATA_MIN_IFACE}.dylib \
+		${libdir}/libgetdata.${GETDATA_MIN_IFACE}.dylib \
 		${DESTDIR}${perlautogetdatadir}/GetData.${PERL_dlext}
 endif
 

--- a/configure.ac
+++ b/configure.ac
@@ -58,6 +58,8 @@ dnl export version information from m4/version.m4
 AC_SUBST(GETDATA_IFACE_VERSION, [getdata_iface_version])
 AC_SUBST(GETDATA_IMPL_REVISION, [getdata_impl_revision])
 AC_SUBST(GETDATA_IFACE_AGE, [getdata_iface_age])
+getdata_min_iface=`expr ${GETDATA_IFACE_VERSION} - ${GETDATA_IFACE_AGE}`
+AC_SUBST(GETDATA_MIN_IFACE, [$getdata_min_iface])
 AC_SUBST(GETDATAXX_VERSION, [getdataxx_version])
 AC_SUBST(FGETDATA_VERSION, [fgetdata_version])
 AC_SUBST(F95GETDATA_VERSION, [f95getdata_version])
@@ -418,7 +420,7 @@ elif test "x$gd_unaligned_override" = "xno"; then
   AC_MSG_RESULT([no (forced)])
 else
   case "${host}" in
-    i?86-*-*|powerpc*-*-*|x86_64-*-*|armv[6789]*-*-*) gd_unaligned_ok=yes ;;
+    i?86-*-*|powerpc*-*-*|x86_64-*-*|armv[6789]*-*-*|aarch64-*-*) gd_unaligned_ok=yes ;;
   *) gd_unaligned_ok=no ;;
   esac
   AC_MSG_RESULT([$gd_unaligned_ok])

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -186,8 +186,8 @@ nodist_noinst_DATA = libpath_mangled
 libpath_mangled: ${nodist_python_SCRIPTS}
 	for m in ${module_LTLIBRARIES}; do \
 		${INSTALL_NAME_TOOL} -change \
-		${libdir}/libgetdata.${GETDATA_IFACE_VERSION}.dylib \
-		${abs_top_builddir}/src/.libs/libgetdata.${GETDATA_IFACE_VERSION}.dylib \
+		${libdir}/libgetdata.${GETDATA_MIN_IFACE}.dylib \
+		${abs_top_builddir}/src/.libs/libgetdata.${GETDATA_MIN_IFACE}.dylib \
 		.libs/`basename $$m .la`-${GETDATA_LIB_VERSION}.so; \
 		done
 	touch $@
@@ -196,8 +196,8 @@ libpath_mangled: ${nodist_python_SCRIPTS}
 install-data-hook:
 	for m in ${module_LTLIBRARIES}; do \
 		${INSTALL_NAME_TOOL} -change \
-		${abs_top_builddir}/src/.libs/libgetdata.${GETDATA_IFACE_VERSION}.dylib \
-		${libdir}/libgetdata.${GETDATA_IFACE_VERSION}.dylib \
+		${abs_top_builddir}/src/.libs/libgetdata.${GETDATA_MIN_IFACE}.dylib \
+		${libdir}/libgetdata.${GETDATA_MIN_IFACE}.dylib \
 		${DESTDIR}${moduledir}/`basename $$m .la`-${GETDATA_LIB_VERSION}.so; \
 		done
 endif


### PR DESCRIPTION
- Fix generation of .dylib name
- Fix post-install path demangling for perl bindings
- Turn on fast-unaligned memory access on aarch64
- Bump minimum automake to 1.16

Closes #5