### PR TITLE
Workflow for PyPI wheels

### DIFF
--- a/.github/workflows/bootstrap.sh
+++ b/.github/workflows/bootstrap.sh
@@ -1,0 +1,21 @@
+#!/bin/sh
+
+set -e
+
+here=$(cd `dirname $0`; pwd -P)
+echo $here
+cd $here/../../
+
+autoreconf -i
+./configure --disable-php \
+            --disable-fortran \
+            --disable-perl \
+            --disable-matlab \
+            --disable-idl \
+            --disable-cplusplus \
+            --with-python=`which python3` \
+            --with-pcre=$PREFIX \
+            --with-ltdl=$PREFIX \
+            --with-liblzma=$PREFIX \
+            --with-libFLAC=$PREFIX \
+            $@

--- a/.github/workflows/bootstrap.sh
+++ b/.github/workflows/bootstrap.sh
@@ -13,9 +13,11 @@ autoreconf -i
             --disable-matlab \
             --disable-idl \
             --disable-cplusplus \
+            --disable-modules \
             --with-python=`which python3` \
             --with-pcre=$PREFIX \
             --with-ltdl=$PREFIX \
             --with-liblzma=$PREFIX \
             --with-libFLAC=$PREFIX \
+            --with-libzzip=$PREFIX \
             $@

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -1,0 +1,152 @@
+name: Wheels
+
+on:
+  workflow_dispatch:
+  pull_request:
+    branches: [ master ]
+  release:
+    types: [ published ]
+
+jobs:
+  build_wheels:
+    name: Build wheels for ${{ matrix.build }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          # macos-13 is an intel runner, macos-14 is apple silicon
+          - os: macos-13
+            python: '3.8'
+            build: 'cp38-macosx_x86_64'
+            target: '13.0'
+            prefix: /usr/local
+
+          - os: macos-13
+            python: '3.9'
+            build: 'cp39-macosx_x86_64'
+            target: '13.0'
+            prefix: /usr/local
+
+          - os: macos-13
+            python: '3.10'
+            build: 'cp310-macosx_x86_64'
+            target: '13.0'
+            prefix: /usr/local
+
+          - os: macos-13
+            python: '3.11'
+            build: 'cp311-macosx_x86_64'
+            target: '13.0'
+            prefix: /usr/local
+
+          - os: macos-13
+            python: '3.12'
+            build: 'cp312-macosx_x86_64'
+            target: '13.0'
+            prefix: /usr/local
+
+          - os: macos-14
+            python: '3.9'
+            build: 'cp39-macosx_arm64'
+            target: '14.0'
+            prefix: /opt/homebrew
+
+          - os: macos-14
+            python: '3.10'
+            build: 'cp310-macosx_arm64'
+            target: '14.0'
+            prefix: /opt/homebrew
+
+          - os: macos-14
+            python: '3.11'
+            build: 'cp311-macosx_arm64'
+            target: '14.0'
+            prefix: /opt/homebrew
+
+          - os: macos-14
+            python: '3.12'
+            build: 'cp312-macosx_arm64'
+            target: '14.0'
+            prefix: /opt/homebrew
+
+          - os: ubuntu-latest
+            python: '3.12'
+            build: 'cp*-manylinux_x86_64'
+            prefix: /usr
+
+    steps:
+      - name: Setup environment
+        run: echo "PREFIX=${{ matrix.prefix }}" >> $GITHUB_ENV
+
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          fetch-tags: true
+
+      # Used to host cibuildwheel
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python }}
+
+      - name: Setup macOS environment
+        if: runner.os == 'macOS'
+        run: |
+          brew install automake libtool
+          echo "MACOSX_DEPLOYMENT_TARGET=${{ matrix.target }}" >> $GITHUB_ENV
+          echo CPPFLAGS="`python3-config --includes`" >> $GITHUB_ENV
+
+      - name: Install cibuildwheel
+        run: python -m pip install cibuildwheel==2.21.3
+
+      - name: Build wheels
+        run: python -m cibuildwheel --output-dir wheelhouse bindings/python
+        env:
+          CIBW_BUILD: ${{ matrix.build }}
+          CIBW_SKIP: cp36* cp37* cp313*
+          CIBW_BEFORE_ALL_LINUX: >
+            yum install -y bzip2-devel flac-devel xz-devel pcre-devel &&
+            .github/workflows/bootstrap.sh --disable-python &&
+            make
+          CIBW_BEFORE_ALL_MACOS: >
+            brew install bzip2 flac xz pcre &&
+            .github/workflows/bootstrap.sh --disable-python &&
+            make
+          CIBW_BEFORE_BUILD: >
+            python -m pip install oldest-supported-numpy &&
+            .github/workflows/bootstrap.sh &&
+            make -C bindings/python pyconstants.c
+          CIBW_REPAIR_WHEEL_COMMAND_LINUX: >
+            LD_LIBRARY_PATH=$PWD/src/.libs auditwheel repair -w {dest_dir} {wheel}
+          CIBW_REPAIR_WHEEL_COMMAND_MACOS: >
+            DYLD_LIBRARY_PATH=$PWD/src/.libs delocate-wheel --require-archs {delocate_archs} -w {dest_dir} -v {wheel}
+          CIBW_BUILD_VERBOSITY: 1
+          CIBW_TEST_COMMAND: >
+            cd {package}/test &&
+            PYTHONPATH=`python -c 'import sysconfig; print(sysconfig.get_paths()["purelib"])'`:$PYTHONPATH make check
+
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: cibw-wheel-${{ matrix.os }}-${{ matrix.python }}
+          path: ./wheelhouse/pygetdata*.whl
+
+  upload_pypi:
+    needs: [build_wheels]
+    runs-on: ubuntu-latest
+    environment: pypi
+    permissions:
+      id-token: write
+    if: github.event_name == 'release' && github.event.action == 'published'
+    steps:
+      - name: Download artifacts
+        uses: actions/download-artifact@v4
+        with:
+          # unpacks all CIBW artifacts into dist/
+          pattern: cibw-*
+          path: dist
+          merge-multiple: true
+
+      - name: Publish package distributions to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -106,11 +106,11 @@ jobs:
           CIBW_BUILD: ${{ matrix.build }}
           CIBW_SKIP: cp36* cp37* cp313*
           CIBW_BEFORE_ALL_LINUX: >
-            yum install -y bzip2-devel flac-devel xz-devel pcre-devel &&
+            yum install -y bzip2-devel flac-devel xz-devel pcre-devel zziplib-devel &&
             .github/workflows/bootstrap.sh --disable-python &&
             make
           CIBW_BEFORE_ALL_MACOS: >
-            brew install bzip2 flac xz pcre &&
+            brew install bzip2 flac xz pcre libzzip &&
             .github/workflows/bootstrap.sh --disable-python &&
             make
           CIBW_BEFORE_BUILD: >

--- a/bindings/python/pyproject.toml
+++ b/bindings/python/pyproject.toml
@@ -1,0 +1,16 @@
+[build-system]
+requires = ["setuptools", "setuptools-scm", "wheel", "oldest-supported-numpy"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "pygetdata"
+dependencies = ["numpy<2.0"]
+dynamic = ["version"]
+
+[tool.setuptools]
+script-files = ["../../util/dirfile2ascii", "../../util/checkdirfile"]
+
+[tool.setuptools_scm]
+version_scheme = "only-version"
+local_scheme = "no-local-version"
+


### PR DESCRIPTION
This PR builds wheels for Python versions 3.8 through 3.12, for many of the common Linux and OSX architectures using [cibuildwheel](https://cibuildwheel.pypa.io/en/stable/).  I hope you find this useful!

I've put this together within the constraints of the build system, so that the workflow is largely just using `autotools` to prepare everything except compiling the python package.  I've also added a very minimal `pyproject.toml` file to enable the cibuildwheel framework to do its thing.  Feel free to rearrange, add metadata, etc.

Each wheel is built against the oldest supported numpy version (https://pypi.org/project/oldest-supported-numpy/), then repaired such that `libgetdata` and any shared encoding libraries are bundled with the python module.

The publisher action will automatically upload a new release assuming you add this repo as a [trusted publisher](https://docs.pypi.org/trusted-publishers/) on PyPI in advance.  I'm assuming you're not ready for a new release yet, so the workflow also uploads the wheels as artifacts with the action if you want to be able to inspect / test them without a release.