### PR TITLE
Fix complex-typed reads of LINCOMs with real scalar parameters

### DIFF
--- a/src/common.c
+++ b/src/common.c
@@ -608,31 +608,48 @@ void _GD_LinterpData(DIRFILE *restrict D, void *data, gd_type_t type,
 #define LINCOM1(t) for (i = 0; i < n_read; i++) \
                             ((t *)data1)[i] = (t)(((t *)data1)[i] * m[0] + b[0])
 
-#define LINCOM2(t) for (i = 0; i < n_read; i++) \
-                            ((t *)data1)[i] = (t)(((t *)data1)[i] * m[0] + \
-                              (data2[i * spf[1] / spf[0]] * m[1] + b[0] + b[1]))
+#define LINCOM2(tout, tin) \
+  do { \
+    const tin *in2 = (const tin *)data2; \
+    for (i = 0; i < n_read; i++) \
+      ((tout *)data1)[i] = (tout)(((tout *)data1)[i] * m[0] + \
+          (in2[i * spf[1] / spf[0]] * m[1] + b[0] + b[1])); \
+  } while (0)
 
-#define LINCOM3(t) for (i = 0; i < n_read; i++) \
-                            ((t *)data1)[i] = (t)(((t *)data1)[i] * m[0] + \
-                              (data2[i * spf[1] / spf[0]] * m[1] + \
-                               data3[i * spf[2] / spf[0]] * m[2] + \
-                               b[0] + b[1] + b[2]))
+#define LINCOM3(tout, tin) \
+  do { \
+    const tin *in2 = (const tin *)data2; \
+    const tin *in3 = (const tin *)data3; \
+    for (i = 0; i < n_read; i++) \
+      ((tout *)data1)[i] = (tout)(((tout *)data1)[i] * m[0] + \
+          (in2[i * spf[1] / spf[0]] * m[1] + \
+           in3[i * spf[2] / spf[0]] * m[2] + \
+           b[0] + b[1] + b[2])); \
+  } while (0)
 
 #ifdef GD_NO_C99_API
+
+/* In the complex-valued LINCOMC macros below, data1 contains complex data
+ * of the return type (which the first field was read as), but data2 and
+ * data3, although declared double*, contain GD_COMPLEX128 data (which is
+ * how _GD_DoLincom reads subsequent input fields when the return type is
+ * complex). */
 #define LINCOMC1(t) \
   do { \
     for (i = 0; i < n_read; i++) { \
-      ((t *)data1)[2 * i] = (t)(((t *)data1)[i] * m[0] + b[0]); \
-      ((t *)data1)[2 * i + 1] = 0; \
+      ((t *)data1)[2 * i] = (t)(((t *)data1)[2 * i] * m[0] + b[0]); \
+      ((t *)data1)[2 * i + 1] = (t)(((t *)data1)[2 * i + 1] * m[0]); \
     } \
   } while (0)
 
 #define LINCOMC2(t) \
   do { \
     for (i = 0; i < n_read; i++) { \
-      ((t *)data1)[2 * i] = (t)(((t *)data1)[i] * m[0] + \
-        (data2[i * spf[1] / spf[0]] * m[1] + b[0] + b[1])); \
-      ((t *)data1)[2 * i + 1] = 0; \
+      const int i2 = 2 * (i * spf[1] / spf[0]); \
+      ((t *)data1)[2 * i] = (t)(((t *)data1)[2 * i] * m[0] + \
+        (data2[i2] * m[1] + b[0] + b[1])); \
+      ((t *)data1)[2 * i + 1] = (t)(((t *)data1)[2 * i + 1] * m[0] + \
+        data2[i2 + 1] * m[1]); \
     } \
   } while (0)
 
@@ -640,13 +657,22 @@ void _GD_LinterpData(DIRFILE *restrict D, void *data, gd_type_t type,
 #define LINCOMC3(t) \
   do { \
     for (i = 0; i < n_read; i++) { \
-      ((t *)data1)[2 * i] = (t)(((t *)data1)[i] * m[0] + \
-        (data2[i * spf[1] / spf[0]] * m[1] + \
-         data3[i * spf[2] / spf[0]] * m[2] + \
+      const int i2 = 2 * (i * spf[1] / spf[0]); \
+      const int i3 = 2 * (i * spf[2] / spf[0]); \
+      ((t *)data1)[2 * i] = (t)(((t *)data1)[2 * i] * m[0] + \
+        (data2[i2] * m[1] + \
+         data3[i3] * m[2] + \
          b[0] + b[1] + b[2])); \
-      ((t *)data1)[2 * i + 1] = 0; \
+      ((t *)data1)[2 * i + 1] = (t)(((t *)data1)[2 * i + 1] * m[0] + \
+        data2[i2 + 1] * m[1] + \
+        data3[i3 + 1] * m[2]); \
     } \
   } while (0)
+#else
+#define LINCOMC1(t) LINCOM1(t _Complex)
+#define LINCOMC2(t) LINCOM2(t _Complex, double _Complex)
+#define LINCOMC3(t) LINCOM3(t _Complex, double _Complex)
+#endif
 
 #define LINCOMC(t) \
   switch (n) { \
@@ -655,15 +681,12 @@ void _GD_LinterpData(DIRFILE *restrict D, void *data, gd_type_t type,
     case 3: LINCOMC3(t); break; \
     default: _GD_InternalError(D); \
   }
-#else
-#define LINCOMC(t) LINCOM(_Complex t)
-#endif
 
-#define LINCOM(t) \
+#define LINCOM(tout, tin) \
   switch (n) { \
-    case 1: LINCOM1(t); break; \
-    case 2: LINCOM2(t); break; \
-    case 3: LINCOM3(t); break; \
+    case 1: LINCOM1(tout); break; \
+    case 2: LINCOM2(tout, tin); break; \
+    case 3: LINCOM3(tout, tin); break; \
     default: _GD_InternalError(D); \
   }
 
@@ -679,19 +702,19 @@ void _GD_LincomData(DIRFILE *restrict D, int n, void *restrict data1,
       return_type, data2, data3, m, b, spf, n_read);
 
   switch(return_type) {
-    case GD_NULL:                         break;
-    case GD_UINT8:      LINCOM(uint8_t);  break;
-    case GD_INT8:       LINCOM(int8_t);   break;
-    case GD_UINT16:     LINCOM(uint16_t); break;
-    case GD_INT16:      LINCOM(int16_t);  break;
-    case GD_UINT32:     LINCOM(uint32_t); break;
-    case GD_INT32:      LINCOM(int32_t);  break;
-    case GD_UINT64:     LINCOM(uint64_t); break;
-    case GD_INT64:      LINCOM(int64_t);  break;
-    case GD_FLOAT32:    LINCOM(float);    break;
-    case GD_FLOAT64:    LINCOM(double);   break;
-    case GD_COMPLEX64:  LINCOMC(float);   break;
-    case GD_COMPLEX128: LINCOMC(double);  break;
+    case GD_NULL:                                 break;
+    case GD_UINT8:      LINCOM(uint8_t,  double); break;
+    case GD_INT8:       LINCOM(int8_t,   double); break;
+    case GD_UINT16:     LINCOM(uint16_t, double); break;
+    case GD_INT16:      LINCOM(int16_t,  double); break;
+    case GD_UINT32:     LINCOM(uint32_t, double); break;
+    case GD_INT32:      LINCOM(int32_t,  double); break;
+    case GD_UINT64:     LINCOM(uint64_t, double); break;
+    case GD_INT64:      LINCOM(int64_t,  double); break;
+    case GD_FLOAT32:    LINCOM(float,    double); break;
+    case GD_FLOAT64:    LINCOM(double,   double); break;
+    case GD_COMPLEX64:  LINCOMC(float);           break;
+    case GD_COMPLEX128: LINCOMC(double);          break;
     default:            _GD_InternalError(D);
   }
 
@@ -707,26 +730,28 @@ void _GD_LincomData(DIRFILE *restrict D, int n, void *restrict data1,
 #undef LINCOMC2
 #undef LINCOMC3
 
+/* In these C89 versions, the input buffers always hold complex data as
+ * interleaved real/imaginary pairs, so tin is unused. */
 #define LINCOM1(t) for (i = 0; i < n_read; i++) \
                             ((t *)data1)[i] = (t)(((t *)data1)[i] * m[0][0] + \
                               b[0][0])
 
-#define LINCOM2(t) \
+#define LINCOM2(tout, tin) \
   do { \
     for (i = 0; i < n_read; i++) { \
       const int i2 = 2 * (i * spf[1] / spf[0]); \
-      ((t *)data1)[i] = (t)(((t *)data1)[i] * m[0][0] + \
+      ((tout *)data1)[i] = (tout)(((tout *)data1)[i] * m[0][0] + \
         (data2[i2] * m[1][0] - data2[i2 + 1] * m[1][1] + b[0][0] + b[1][0])); \
     } \
   } while (0)
 
 
-#define LINCOM3(t) \
+#define LINCOM3(tout, tin) \
   do { \
     for (i = 0; i < n_read; i++) { \
       const int i2 = 2 * (i * spf[1] / spf[0]); \
       const int i3 = 2 * (i * spf[2] / spf[0]); \
-      ((t *)data1)[i] = (t)(((t *)data1)[i] * m[0][0] + \
+      ((tout *)data1)[i] = (tout)(((tout *)data1)[i] * m[0][0] + \
         (data2[i2] * m[1][0] - data2[i2 + 1] * m[1][1] + \
          data3[i3] * m[2][0] - data3[i3 + 1] * m[2][1] + \
          b[0][0] + b[1][0] + b[2][0])); \
@@ -788,19 +813,19 @@ void _GD_CLincomData(DIRFILE *restrict D, int n, void *restrict data1,
       return_type, data2, data3, m, b, spf, n_read);
 
   switch(return_type) {
-    case GD_NULL:                         break;
-    case GD_UINT8:      LINCOM(uint8_t);  break;
-    case GD_INT8:       LINCOM(int8_t);   break;
-    case GD_UINT16:     LINCOM(uint16_t); break;
-    case GD_INT16:      LINCOM(int16_t);  break;
-    case GD_UINT32:     LINCOM(uint32_t); break;
-    case GD_INT32:      LINCOM(int32_t);  break;
-    case GD_UINT64:     LINCOM(uint64_t); break;
-    case GD_INT64:      LINCOM(int64_t);  break;
-    case GD_FLOAT32:    LINCOM(float);    break;
-    case GD_FLOAT64:    LINCOM(double);   break;
-    case GD_COMPLEX64:  LINCOMC(float);   break;
-    case GD_COMPLEX128: LINCOMC(double);  break;
+    case GD_NULL:                                          break;
+    case GD_UINT8:      LINCOM(uint8_t,  double _Complex); break;
+    case GD_INT8:       LINCOM(int8_t,   double _Complex); break;
+    case GD_UINT16:     LINCOM(uint16_t, double _Complex); break;
+    case GD_INT16:      LINCOM(int16_t,  double _Complex); break;
+    case GD_UINT32:     LINCOM(uint32_t, double _Complex); break;
+    case GD_INT32:      LINCOM(int32_t,  double _Complex); break;
+    case GD_UINT64:     LINCOM(uint64_t, double _Complex); break;
+    case GD_INT64:      LINCOM(int64_t,  double _Complex); break;
+    case GD_FLOAT32:    LINCOM(float,    double _Complex); break;
+    case GD_FLOAT64:    LINCOM(double,   double _Complex); break;
+    case GD_COMPLEX64:  LINCOMC(float);                    break;
+    case GD_COMPLEX128: LINCOMC(double);                   break;
     default:            _GD_InternalError(D);
   }
 

--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -265,7 +265,8 @@ GET_TESTS=get64 get_affix get_bad_code get_bit get_carray get_carray_bad \
 					get_foffs2 get_fs get_here get_here_foffs get_heres \
 					get_index_complex get_index_type get_indir get_indir_typein get_int8 \
 					get_int16 get_int32 get_int64 get_invalid get_lincom1 get_lincom2 \
-					get_lincom2s get_lincom3 get_lincom3s get_lincom_mdt get_lincom_noin \
+					get_lincom2s get_lincom3 get_lincom3s get_lincom_complex \
+					get_lincom_mdt get_lincom_noin \
 					get_lincom_non get_lincom_null get_lincom_spf get_lincom_code \
 					get_linterp get_linterp1 get_linterp_abs get_linterp_complex \
 					get_linterp_empty get_linterp_nodir get_linterp_noin \

--- a/test/get_lincom_complex.c
+++ b/test/get_lincom_complex.c
@@ -1,0 +1,119 @@
+/* Copyright (C) 2026 Graeme Smecher
+ *
+ ***************************************************************************
+ *
+ * This file is part of the GetData project.
+ *
+ * GetData is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the
+ * Free Software Foundation; either version 2.1 of the License, or (at your
+ * option) any later version.
+ *
+ * GetData is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with GetData; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+#include "test.h"
+
+/* A LINCOM with purely real coefficients must return the same values when
+ * read with a complex return type as it does when read with a real return
+ * type, and must propagate the imaginary parts of complex-valued inputs.
+ *
+ * The first two fields sum copies of a real-valued input, so:
+ * lincom2[n] = 2 * data[n] and lincom3[n] = 3 * data[n], with zero
+ * imaginary parts.
+ *
+ * The last two fields have a complex-valued input, cdata[n] = 2n + (2n+1)i,
+ * whose imaginary part must survive scaling by the real coefficients:
+ * clincom2[n] = 2 * cdata[n] and clincom1[n] = 2 * cdata[n] + 3.  (The
+ * single-input clincom1 avoids gain 1 and offset 0, which GetData
+ * short-circuits as a rename without computing anything.)
+ *
+ * The reads start at sample 5 rather than sample 0 because sample 0 can be
+ * computed correctly even by an implementation that confuses complex and
+ * real buffer indices (index 0 is index 0 either way). */
+
+int main(void)
+{
+  const char *filedir = "dirfile";
+  const char *format = "dirfile/format";
+  const char *data = "dirfile/data";
+  const char *cdata = "dirfile/cdata";
+  double c1[16], c2[16], c3[16], c4[16];
+  int i, n1, n2, n3, n4, error1, error2, error3, error4, r = 0;
+  DIRFILE *D;
+
+  memset(c1, 0, sizeof(c1));
+  memset(c2, 0, sizeof(c2));
+  memset(c3, 0, sizeof(c3));
+  memset(c4, 0, sizeof(c4));
+
+  rmdirfile();
+  mkdir(filedir, 0700);
+
+  MAKEFORMATFILE(format,
+    "lincom2 LINCOM 2 data 1 0 data 1 0\n"
+    "lincom3 LINCOM 3 data 1 0 data 1 0 data 1 0\n"
+    "clincom2 LINCOM 2 cdata 1 0 cdata 1 0\n"
+    "clincom1 LINCOM 1 cdata 2 3\n"
+    "data RAW UINT8 1\n"
+    "cdata RAW COMPLEX128 1\n"
+  );
+  MAKEDATAFILE(data, unsigned char, i, 256);
+  MAKEDATAFILE(cdata, double, i, 512);
+
+  D = gd_open(filedir, GD_RDONLY | GD_VERBOSE);
+  n1 = gd_getdata(D, "lincom2", 5, 0, 8, 0, GD_COMPLEX128, &c1);
+  error1 = gd_error(D);
+
+  n2 = gd_getdata(D, "lincom3", 5, 0, 8, 0, GD_COMPLEX128, &c2);
+  error2 = gd_error(D);
+
+  n3 = gd_getdata(D, "clincom2", 5, 0, 8, 0, GD_COMPLEX128, &c3);
+  error3 = gd_error(D);
+
+  n4 = gd_getdata(D, "clincom1", 5, 0, 8, 0, GD_COMPLEX128, &c4);
+  error4 = gd_error(D);
+
+  gd_discard(D);
+
+  unlink(cdata);
+  unlink(data);
+  unlink(format);
+  rmdir(filedir);
+
+  CHECKI(error1, 0);
+  CHECKI(n1, 8);
+  for (i = 0; i < 8; ++i) {
+    CHECKFi(i, c1[2 * i], 2 * (5 + i));
+    CHECKFi(i, c1[2 * i + 1], 0);
+  }
+
+  CHECKI(error2, 0);
+  CHECKI(n2, 8);
+  for (i = 0; i < 8; ++i) {
+    CHECKFi(i, c2[2 * i], 3 * (5 + i));
+    CHECKFi(i, c2[2 * i + 1], 0);
+  }
+
+  CHECKI(error3, 0);
+  CHECKI(n3, 8);
+  for (i = 0; i < 8; ++i) {
+    CHECKFi(i, c3[2 * i], 4 * (5 + i));
+    CHECKFi(i, c3[2 * i + 1], 4 * (5 + i) + 2);
+  }
+
+  CHECKI(error4, 0);
+  CHECKI(n4, 8);
+  for (i = 0; i < 8; ++i) {
+    CHECKFi(i, c4[2 * i], 4 * (5 + i) + 3);
+    CHECKFi(i, c4[2 * i + 1], 4 * (5 + i) + 2);
+  }
+
+  return r;
+}


### PR DESCRIPTION
When gd_getdata() requests complex-typed data from a multi-input LINCOM whose scalar parameters are purely real, _GD_DoLincom() reads the second and third input fields as GD_COMPLEX128, but _GD_LincomData() indexed those buffers as double.  Every output sample other than the first mixed real and imaginary halves of the wrong input elements.

The C89 (GD_NO_C99_API) variants of these macros were additionally broken: they indexed data1 as if it held packed real values (clobbering it in place) and zeroed the output's imaginary part rather than scaling the input's.  Because MSVC still does not support _Complex, the C89 path is still necessary.

Now, instead of just casting to the output type, the LINCOM macros with nontrivial types accept a (tout, tin) type tuple and cast explicitly. This results in correct and simpler code.

A regression test (get_lincom_complex) has been added to verify correct behaviour. Before the fix, a C89 build (Linux) reports:

    i:1 c1[2 * i] = 0 (expected 12)
    i:2 c1[2 * i] = 6 (expected 14)
    i:3 c1[2 * i] = 0 (expected 16)
    i:4 c1[2 * i] = 13 (expected 18)
    i:5 c1[2 * i] = 0 (expected 20)
    i:6 c1[2 * i] = 8 (expected 22)
    i:7 c1[2 * i] = 0 (expected 24)
    i:1 c2[2 * i] = 0 (expected 18)
    i:2 c2[2 * i] = 12 (expected 21)
    i:3 c2[2 * i] = 0 (expected 24)
    i:4 c2[2 * i] = 26 (expected 27)
    i:5 c2[2 * i] = 0 (expected 30)
    i:6 c2[2 * i] = 16 (expected 33)
    i:7 c2[2 * i] = 0 (expected 36)
    i:0 c3[2 * i + 1] = 0 (expected 22)
    i:1 c3[2 * i] = 11 (expected 24)
    i:1 c3[2 * i + 1] = 0 (expected 26)
    i:2 c3[2 * i] = 23 (expected 28)
    i:2 c3[2 * i + 1] = 0 (expected 30)
    i:3 c3[2 * i] = 13 (expected 32)
    i:3 c3[2 * i + 1] = 0 (expected 34)
    i:4 c3[2 * i] = 37 (expected 36)
    i:4 c3[2 * i + 1] = 0 (expected 38)
    i:5 c3[2 * i] = 15 (expected 40)
    i:5 c3[2 * i + 1] = 0 (expected 42)
    i:6 c3[2 * i] = 29 (expected 44)
    i:6 c3[2 * i + 1] = 0 (expected 46)
    i:7 c3[2 * i] = 17 (expected 48)
    i:7 c3[2 * i + 1] = 0 (expected 50)
    i:0 c4[2 * i + 1] = 0 (expected 22)
    i:1 c4[2 * i] = 3 (expected 27)
    i:1 c4[2 * i + 1] = 0 (expected 26)
    i:2 c4[2 * i] = 9 (expected 31)
    i:2 c4[2 * i + 1] = 0 (expected 30)
    i:3 c4[2 * i] = 3 (expected 35)
    i:3 c4[2 * i + 1] = 0 (expected 34)
    i:4 c4[2 * i] = 21 (expected 39)
    i:4 c4[2 * i + 1] = 0 (expected 38)
    i:5 c4[2 * i] = 3 (expected 43)
    i:5 c4[2 * i + 1] = 0 (expected 42)
    i:6 c4[2 * i] = 9 (expected 47)
    i:6 c4[2 * i + 1] = 0 (expected 46)
    i:7 c4[2 * i] = 3 (expected 51)
    i:7 c4[2 * i + 1] = 0 (expected 50)
    FAIL: get_lincom_complex

and a C99 build (Linux) reports:

    i:1 c1[2 * i] = 6 (expected 12)
    i:2 c1[2 * i] = 13 (expected 14)
    i:3 c1[2 * i] = 8 (expected 16)
    i:4 c1[2 * i] = 16 (expected 18)
    i:5 c1[2 * i] = 10 (expected 20)
    i:6 c1[2 * i] = 19 (expected 22)
    i:7 c1[2 * i] = 12 (expected 24)
    i:1 c2[2 * i] = 6 (expected 18)
    i:2 c2[2 * i] = 19 (expected 21)
    i:3 c2[2 * i] = 8 (expected 24)
    i:4 c2[2 * i] = 23 (expected 27)
    i:5 c2[2 * i] = 10 (expected 30)
    i:6 c2[2 * i] = 27 (expected 33)
    i:7 c2[2 * i] = 12 (expected 36)
    i:0 c3[2 * i + 1] = 11 (expected 22)
    i:1 c3[2 * i] = 23 (expected 24)
    i:1 c3[2 * i + 1] = 13 (expected 26)
    i:2 c3[2 * i] = 26 (expected 28)
    i:2 c3[2 * i + 1] = 15 (expected 30)
    i:3 c3[2 * i] = 29 (expected 32)
    i:3 c3[2 * i + 1] = 17 (expected 34)
    i:4 c3[2 * i] = 32 (expected 36)
    i:4 c3[2 * i + 1] = 19 (expected 38)
    i:5 c3[2 * i] = 35 (expected 40)
    i:5 c3[2 * i + 1] = 21 (expected 42)
    i:6 c3[2 * i] = 38 (expected 44)
    i:6 c3[2 * i + 1] = 23 (expected 46)
    i:7 c3[2 * i] = 41 (expected 48)
    i:7 c3[2 * i + 1] = 25 (expected 50)
    FAIL: get_lincom_complex

...indicating (different) bugs in the two code paths.