### PR TITLE
CMake: CI/CD churn: fix zzip and zlib detection on Windows/vcpkg

### DIFF
--- a/.github/workflows/cmake-ci.yml
+++ b/.github/workflows/cmake-ci.yml
@@ -44,8 +44,21 @@ jobs:
           echo "CMAKE_PREFIX_PATH=$VCPKG_INSTALLATION_ROOT/installed/x64-windows-static-md" >> $GITHUB_ENV
 
       - name: Configure CMake
+        if: runner.os != 'Windows'
         working-directory: cmake
         run: cmake -B build -DBUILD_PYTHON=ON -DGD_TEST=ON
+
+      # The vcpkg toolchain file is required for find_package(ZLIB) to work:
+      # vcpkg's static zlib does not match FindZLIB's library names, and is
+      # instead resolved by the vcpkg-cmake-wrapper the toolchain provides.
+      - name: Configure CMake (Windows)
+        if: runner.os == 'Windows'
+        working-directory: cmake
+        shell: bash
+        run: >
+          cmake -B build -DBUILD_PYTHON=ON -DGD_TEST=ON
+          -DCMAKE_TOOLCHAIN_FILE="$VCPKG_INSTALLATION_ROOT/scripts/buildsystems/vcpkg.cmake"
+          -DVCPKG_TARGET_TRIPLET=x64-windows-static-md
 
       - name: Build
         working-directory: cmake

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -79,6 +79,7 @@ jobs:
           CIBW_ENVIRONMENT_WINDOWS: >
             PKG_CONFIG_PATH="$VCPKG_INSTALLATION_ROOT/installed/x64-windows-static-md/lib/pkgconfig"
             CMAKE_PREFIX_PATH="$VCPKG_INSTALLATION_ROOT/installed/x64-windows-static-md"
+            CMAKE_ARGS="-DCMAKE_TOOLCHAIN_FILE=$VCPKG_INSTALLATION_ROOT/scripts/buildsystems/vcpkg.cmake -DVCPKG_TARGET_TRIPLET=x64-windows-static-md"
           CIBW_BEFORE_BUILD: >
             python -m pip install "scikit-build-core>=0.5" "numpy>=2.0"
           CIBW_BEFORE_BUILD_WINDOWS: >

--- a/cmake/CMakeLists.txt
+++ b/cmake/CMakeLists.txt
@@ -76,16 +76,17 @@ if(PKG_CONFIG_FOUND)
   pkg_check_modules(ZZIP zziplib)
 endif()
 
-# Fallback: find zziplib manually when pkg-config fails (e.g. vcpkg on Windows,
-# where the zziplib port doesn't generate .pc files)
+# vcpkg (Windows) ships no zziplib.pc, but exports a CMake config package
+# whose target carries zziplib's zlib dependency.  This requires the vcpkg
+# toolchain file, so that the config's find_dependency(ZLIB) can resolve.
 if(NOT ZZIP_FOUND)
-  find_path(ZZIP_MANUAL_INCLUDE_DIR NAMES zzip/lib.h)
-  find_library(ZZIP_MANUAL_LIBRARY NAMES zzip zzip-0)
-  if(ZZIP_MANUAL_INCLUDE_DIR AND ZZIP_MANUAL_LIBRARY)
+  find_package(zziplib CONFIG QUIET)
+  if(zziplib_FOUND)
     set(ZZIP_FOUND TRUE)
-    set(ZZIP_INCLUDE_DIRS ${ZZIP_MANUAL_INCLUDE_DIR})
-    set(ZZIP_LINK_LIBRARIES ${ZZIP_MANUAL_LIBRARY})
-    set(ZZIP_LIBRARIES ${ZZIP_MANUAL_LIBRARY})
+    set(ZZIP_LINK_LIBRARIES zziplib::libzzip)
+    get_target_property(ZZIP_INCLUDE_DIRS zziplib::libzzip
+      INTERFACE_INCLUDE_DIRECTORIES)
+    message(STATUS "Found zziplib: ${ZZIP_LINK_LIBRARIES}")
   endif()
 endif()
 


### PR DESCRIPTION
vcpkg's zziplib is a static library with no .pc file, and its zlib dependency was not being linked (unresolved inflate/zError when linking getdata.dll). Also, vcpkg's zlib does not match FindZLIB's library names at all, so gzip support was silently disabled on Windows.

Pass the vcpkg toolchain file and triplet explicitly in both Windows CI jobs, and find zziplib through the CMake config package the vcpkg port exports, whose target carries the zlib dependency.