### PR TITLE
cicd: wheels: build outside %TEMP% and disable MSBuild node reuse on Windows

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -80,6 +80,8 @@ jobs:
             PKG_CONFIG_PATH="$VCPKG_INSTALLATION_ROOT/installed/x64-windows-static-md/lib/pkgconfig"
             CMAKE_PREFIX_PATH="$VCPKG_INSTALLATION_ROOT/installed/x64-windows-static-md"
             CMAKE_ARGS="-DCMAKE_TOOLCHAIN_FILE=$VCPKG_INSTALLATION_ROOT/scripts/buildsystems/vcpkg.cmake -DVCPKG_TARGET_TRIPLET=x64-windows-static-md"
+            SKBUILD_BUILD_DIR="build/{wheel_tag}"
+            MSBUILDDISABLENODEREUSE=1
           CIBW_BEFORE_BUILD: >
             python -m pip install "scikit-build-core>=0.5" "numpy>=2.0"
           CIBW_BEFORE_BUILD_WINDOWS: >


### PR DESCRIPTION
Windows wheel builds intermittently fail after a successful compile, link, and per-wheel test, when scikit-build-core removed its temporary build directory:

    PermissionError: [WinError 32] The process cannot access the file
    because it is being used by another process: '...\tmp...\build\util'

scikit-build-core builds each wheel inside a TemporaryDirectory under %TEMP% and deletes it immediately afterwards. The build uses the VS generator, and MSBuild worker processes outlive the build by default (node reuse), so the cleanup races against processes that may still hold handles under the build tree. MSBuild itself warns against this arrangement (MSB8029: intermediate and output directories should not reside under the temporary directory).