### PR TITLE
Fuzzer fixes - lzma_xz and ASCII endcodings

### DIFF
--- a/bindings/python/test/fuzzer.py
+++ b/bindings/python/test/fuzzer.py
@@ -872,6 +872,9 @@ class SparseWriteModel(RuleBasedStateMachine):
     The states worth reaching are combinations -- write past the end to open a
     hole, overwrite backwards across the hole's edge, extend again -- which is
     what a sequence of generated writes explores and a fixed test does not.
+
+    The machine runs over every writable encoding to ensure consistent
+    semantics on top of different plugins.
     """
 
     # Small, so that writes collide often rather than scattering into disjoint
@@ -883,9 +886,10 @@ class SparseWriteModel(RuleBasedStateMachine):
         self.df = None
         self.model = numpy.zeros(0, dtype=numpy.int64)
 
-    @initialize(spf=st.integers(min_value=1, max_value=4))
-    def create(self, spf):
-        self.df = Dirfile()
+    @initialize(spf=st.integers(min_value=1, max_value=4),
+                encoding=st.sampled_from(WRITABLE_ENCODINGS))
+    def create(self, spf, encoding):
+        self.df = Dirfile(encoding=encoding)
         self.spf = spf
         self.df.D.add(gd.entry(gd.RAW_ENTRY, "r", 0,
                                dict(type=gd.INT32, spf=spf)))

--- a/cmake/test/CMakeLists.txt
+++ b/cmake/test/CMakeLists.txt
@@ -24,7 +24,9 @@ set(tests_ignored
   # Helper files (not standalone tests - included by encoding tests)
   enc_add enc_complex128 enc_complex64 enc_del enc_enoent enc_float32
   enc_float64 enc_get_cont enc_int16 enc_int32 enc_int64 enc_int8
-  enc_move_from enc_nframes enc_put_offs enc_seek enc_uint16 enc_uint32
+  enc_get_far enc_get_get enc_get_get2 enc_move_from enc_move_to
+  enc_nframes enc_put enc_put_back enc_put_endian enc_put_get
+  enc_put_nframes enc_put_offs enc_put_pad enc_put_sub enc_seek enc_sync enc_uint16 enc_uint32
   enc_uint64 enc_uint8
 
   desync_path
@@ -49,7 +51,7 @@ if(NOT BZIP2_FOUND OR NOT BZIP2)
     bzip_add bzip_complex128 bzip_complex64 bzip_del bzip_enoent bzip_float32
     bzip_float64 bzip_get bzip_get_cont bzip_get_far bzip_get_get bzip_get_get2
     bzip_get_put bzip_int16 bzip_int32 bzip_int64 bzip_int8 bzip_move_from
-    bzip_move_to bzip_nframes bzip_put bzip_put_back bzip_put_endian bzip_put_get
+    bzip_move_to bzip_nframes bzip_put bzip_put_nframes bzip_put_back bzip_put_endian bzip_put_get
     bzip_put_offs bzip_put_pad bzip_put_sub bzip_seek bzip_seek_far bzip_sync
     bzip_uint16 bzip_uint32 bzip_uint64 bzip_uint8)
 endif()
@@ -73,7 +75,7 @@ if(NOT FLAC_FOUND OR NOT FLAC)
     flac_get_get2 flac_get_int64 flac_get_int8 flac_get_little flac_get_long
     flac_int16 flac_int32 flac_int64 flac_int8 flac_move_from flac_nframes
     flac_put_big flac_put_complex128 flac_put_float64 flac_put_int32
-    flac_put_little flac_put_offs flac_seek flac_seek_far flac_sync flac_uint16
+    flac_put_little flac_put_nframes flac_put_offs flac_seek flac_seek_far flac_sync flac_uint16
     flac_uint32 flac_uint64 flac_uint8)
 endif()
 
@@ -84,7 +86,7 @@ if(NOT LIBLZMA_FOUND OR NOT XZ)
     lzma_xz_get_cont lzma_xz_get_far lzma_xz_get_get lzma_xz_get_get2
     lzma_xz_get_put lzma_xz_int16 lzma_xz_int32 lzma_xz_int64 lzma_xz_int8
     lzma_xz_move_from lzma_xz_move_to lzma_xz_nframes lzma_xz_offs_clear
-    lzma_xz_put lzma_xz_put_back lzma_xz_put_endian lzma_xz_put_get
+    lzma_xz_put lzma_xz_put_nframes lzma_xz_put_back lzma_xz_put_endian lzma_xz_put_get
     lzma_xz_put_offs lzma_xz_put_pad lzma_xz_seek lzma_xz_seek_far lzma_xz_sync
     lzma_xz_uint16 lzma_xz_uint32 lzma_xz_uint64 lzma_xz_uint8)
 endif()

--- a/src/ascii.c
+++ b/src/ascii.c
@@ -63,6 +63,12 @@ off64_t _GD_AsciiSeek(struct gd_raw_file_* file, off64_t count,
   if (count < file->pos) {
     rewind((FILE *)file->edata);
     file->pos = 0;
+  } else if (count > file->pos) {
+    /* reposition between output and input on the update stream */
+    if (fseeko64((FILE *)file->edata, 0, SEEK_CUR)) {
+      dreturn("%i", -1);
+      return -1;
+    }
   }
 
   for (; count > file->pos; ++file->pos)
@@ -71,6 +77,11 @@ off64_t _GD_AsciiSeek(struct gd_raw_file_* file, off64_t count,
 
   if (mode & GD_FILE_WRITE && count > file->pos) {
     strcpy(line, "0\n");
+    /* reposition between input and output on the update stream */
+    if (fseeko64((FILE *)file->edata, 0, SEEK_CUR)) {
+      dreturn("%i", -1);
+      return -1;
+    }
     for (; count > file->pos; ++file->pos)
       fputs(line, (FILE *)file->edata);
   }
@@ -213,9 +224,76 @@ ssize_t _GD_AsciiRead(struct gd_raw_file_ *restrict file, void *restrict ptr,
 ssize_t _GD_AsciiWrite(struct gd_raw_file_ *restrict file,
     const void *restrict ptr, gd_type_t data_type, size_t nmemb)
 {
+  FILE *stream = (FILE *)file->edata;
   ssize_t n = -1;
+  char *tail = NULL;
+  size_t i, tail_len = 0;
+  off64_t start;
+  char line[64];
 
   dtrace("%p, %p, 0x%X, %" PRIuSIZE, file, ptr, data_type, nmemb);
+
+  /* Samples are stored as variable-width lines, so they cannot be
+   * overwritten in place: rewriting a line with a value of a different
+   * width corrupts the lines that follow.  If this write lands on existing
+   * lines, buffer everything following the replaced range, then write it
+   * back after the new samples and truncate. This is inefficient but
+   * maximally consistent with other plugins (and ASCII encodings were
+   * already inefficient.) */
+
+  /* reposition between output and input on the update stream: ftello()
+   * is not a file-positioning function */
+  if (fseeko64(stream, 0, SEEK_CUR)) {
+    dreturn("%i", -1);
+    return -1;
+  }
+
+  start = ftello64(stream);
+  if (start == -1) {
+    dreturn("%i", -1);
+    return -1;
+  }
+
+  for (i = 0; i < nmemb; ++i) {
+    /* consume one full line per sample; a line too long for the buffer
+     * (not something getdata writes, but the file is plain text) takes
+     * several reads */
+    char *p;
+    do
+      p = fgets(line, sizeof(line), stream);
+    while (p != NULL && strchr(line, '\n') == NULL);
+    if (p == NULL)
+      break;
+  }
+
+  if (i == nmemb) {
+    /* the write replaces existing lines; preserve what follows them */
+    char buffer[4096];
+    size_t n_read;
+
+    while ((n_read = fread(buffer, 1, sizeof(buffer), stream)) > 0) {
+      char *new_tail = realloc(tail, tail_len + n_read);
+      if (new_tail == NULL) {
+        free(tail);
+        dreturn("%i", -1);
+        return -1;
+      }
+      memcpy(new_tail + tail_len, buffer, n_read);
+      tail = new_tail;
+      tail_len += n_read;
+    }
+    if (ferror(stream)) {
+      free(tail);
+      dreturn("%i", -1);
+      return -1;
+    }
+  }
+
+  if (fseeko64(stream, start, SEEK_SET)) {
+    free(tail);
+    dreturn("%i", -1);
+    return -1;
+  }
 
   switch (data_type) {
     case GD_UINT8:       WRITE_ASCII(PRIu8 ,  uint8_t); break;
@@ -232,7 +310,19 @@ ssize_t _GD_AsciiWrite(struct gd_raw_file_ *restrict file,
     case GD_COMPLEX128: WRITE_CASCII(".16g",   double); break;
     default:                            errno = EINVAL; break;
   }
-  
+
+  if (n >= 0 && (i > 0 || tail_len > 0)) {
+    /* replace the tail displaced by the overwrite, and discard whatever
+     * remains of the old lines */
+    if (tail_len > 0 && fwrite(tail, 1, tail_len, stream) != tail_len)
+      n = -1;
+    else if (fflush(stream))
+      n = -1;
+    else if (gd_truncate(fileno(stream), ftello64(stream)))
+      n = -1;
+  }
+  free(tail);
+
   file->pos += nmemb;
 
   dreturn("%" PRIdSIZE, n);
@@ -285,7 +375,7 @@ off64_t _GD_AsciiSize(int dirfd, struct gd_raw_file_* file,
 
   dtrace("%i, %p, <unused>, <unused>", dirfd, file);
 
-  fd = gd_OpenAt(file->D, dirfd, file->name, O_RDONLY, 0666);
+  fd = gd_OpenAt(file->D, dirfd, file->name, O_RDONLY | O_BINARY, 0666);
   if (fd < 0) {
     dreturn("%i", -1);
     return -1;

--- a/src/encoding.c
+++ b/src/encoding.c
@@ -510,7 +510,7 @@ int _GD_FiniRawIO(DIRFILE *D, const gd_entry_t *E, int fragment, int flags)
         dreturn("%i", -1);
         return -1;
       }
-    } else {
+    } else if (E->e->u.raw.file[1].name != NULL) {
       /* Move the old file over the new file */
       if (_GD_MoveOver(D, fragment, E->e->u.raw.file)) {
         dreturn("%i", -1);

--- a/src/lzma.c
+++ b/src/lzma.c
@@ -458,6 +458,7 @@ int _GD_LzmaClose(struct gd_raw_file_ *file)
   }
 
   file->idata = -1;
+  file->mode = 0;
   free(file->edata);
   file->edata = NULL;
   dreturn("%i", 0);

--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -108,7 +108,7 @@ ALTER_TESTS=alter_bit_bitnum alter_bit_in alter_bit_numbits alter_bit_scalar \
 						alter_spec_polynom alter_spec_prot alter_spec_rdonly alter_window \
 						alter_window_in alter_window_op alter_window_scalar
 
-ASCII_TESTS=ascii_add ascii_complex64 ascii_complex128 ascii_get \
+ASCII_TESTS=ascii_add ascii_complex64 ascii_complex128 ascii_get ascii_put_back \
 						ascii_get_complex ascii_float32 ascii_float64 ascii_get_get \
 						ascii_get_here ascii_get_sub ascii_int8 ascii_int16 ascii_int32 \
 						ascii_int64 ascii_nframes ascii_put ascii_put_here ascii_seek \

--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -36,7 +36,10 @@ AM_CPPFLAGS=${GD_CC_WALL} $(GD_CC_WEXTRA) -I$(top_srcdir)/src
 # The enc_*.c files aren't directly used as tests.  They're included by
 # corresponding encoding tests.
 EXTRA_DIST=run_test.sh test.h enc_add.c enc_complex64.c enc_complex128.c enc_del.c \
-					 enc_enoent.c enc_float32.c enc_float64.c enc_get_cont.c enc_int8.c \
+					 enc_enoent.c enc_get_far.c enc_get_get.c \
+					 enc_get_get2.c enc_move_to.c enc_put.c enc_put_back.c \
+					 enc_put_endian.c enc_put_get.c enc_put_nframes.c enc_put_pad.c \
+					 enc_put_sub.c enc_sync.c enc_float32.c enc_float64.c enc_get_cont.c enc_int8.c \
 					 enc_int16.c enc_int32.c enc_int64.c enc_move_from.c enc_nframes.c \
 					 enc_put_offs.c enc_seek.c enc_uint8.c enc_uint16.c enc_uint32.c \
 					 enc_uint64.c
@@ -119,7 +122,7 @@ BZIP_TESTS=bzip_add bzip_complex64 bzip_complex128 bzip_del bzip_enoent \
 					 bzip_float32 bzip_float64 bzip_get bzip_get_cont bzip_get_far \
 					 bzip_get_get bzip_get_get2 bzip_get_put bzip_int8 bzip_int16 \
 					 bzip_int32 bzip_int64 bzip_move_from bzip_move_to bzip_nframes \
-					 bzip_put bzip_put_back bzip_put_endian bzip_put_get bzip_put_offs \
+					 bzip_put bzip_put_nframes bzip_put_back bzip_put_endian bzip_put_get bzip_put_offs \
 					 bzip_put_pad bzip_put_sub bzip_seek bzip_seek_far bzip_sync \
 					 bzip_uint8 bzip_uint16 bzip_uint32 bzip_uint64
 
@@ -227,7 +230,7 @@ FLAC_TESTS=flac_add flac_complex64 flac_complex128 flac_del flac_enoent \
 					 flac_get_int64 flac_get_little flac_get_long flac_int8 \
 					 flac_int16 flac_int32 flac_int64 flac_move_from flac_nframes \
 					 flac_put_big flac_put_complex128 flac_put_float64 \
-					 flac_put_int32 flac_put_little flac_put_offs flac_seek \
+					 flac_put_int32 flac_put_little flac_put_nframes flac_put_offs flac_seek \
 					 flac_seek_far flac_sync flac_uint8 flac_uint16 flac_uint32 \
 					 flac_uint64
 
@@ -339,7 +342,7 @@ LZMA_TESTS=lzma_enoent lzma_get lzma_nframes lzma_put lzma_xz_add \
 					 lzma_xz_float64 lzma_xz_get lzma_xz_get_cont lzma_xz_get_far \
 					 lzma_xz_get_get lzma_xz_get_get2 lzma_xz_get_put lzma_xz_int8 \
 					 lzma_xz_int16 lzma_xz_int32 lzma_xz_int64 lzma_xz_move_from \
-					 lzma_xz_move_to lzma_xz_nframes lzma_xz_offs_clear lzma_xz_put \
+					 lzma_xz_move_to lzma_xz_nframes lzma_xz_offs_clear lzma_xz_put lzma_xz_put_nframes \
 					 lzma_xz_put_back lzma_xz_put_endian lzma_xz_put_get \
 					 lzma_xz_put_offs lzma_xz_put_pad lzma_xz_seek lzma_xz_seek_far \
 					 lzma_xz_sync lzma_xz_uint8 lzma_xz_uint16 lzma_xz_uint32 \

--- a/test/ascii_put_back.c
+++ b/test/ascii_put_back.c
@@ -1,0 +1,81 @@
+/* Copyright (C) 2026 G. Smecher
+ *
+ ***************************************************************************
+ *
+ * This file is part of the GetData project.
+ *
+ * GetData is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the
+ * Free Software Foundation; either version 2.1 of the License, or (at your
+ * option) any later version.
+ *
+ * GetData is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with GetData; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+#include "test.h"
+
+/* Overwriting text-encoded samples must preserve the lines that follow,
+ * even when the replacement lines differ in width */
+int main(void)
+{
+  const char *filedir = "dirfile";
+  const char *format = "dirfile/format";
+  const char *data = "dirfile/data.txt";
+  int32_t d, c[2];
+  int n, e, r = 0;
+  DIRFILE *D;
+
+  rmdirfile();
+  mkdir(filedir, 0700);
+
+  MAKEFORMATFILE(format, "data RAW INT32 1\n");
+
+  D = gd_open(filedir, GD_RDWR | GD_TEXT_ENCODED | GD_VERBOSE);
+
+  /* write sample 1, leaving a zero-filled hole at sample 0 */
+  d = 2;
+  n = gd_putdata(D, "data", 1, 0, 0, 1, GD_INT32, &d);
+  CHECKI(n, 1);
+
+  /* backfill sample 0 with a wider value */
+  d = -1000000;
+  n = gd_putdata(D, "data", 0, 0, 0, 1, GD_INT32, &d);
+  CHECKI(n, 1);
+
+  e = gd_error(D);
+  CHECKI(e, GD_E_OK);
+
+  n = (int)gd_getdata(D, "data", 0, 0, 2, 0, GD_INT32, c);
+  CHECKI(n, 2);
+  CHECKIi(0, c[0], -1000000);
+  CHECKIi(1, c[1], 2);
+  CHECKI(gd_eof64(D, "data"), 2);
+
+  /* overwrite sample 0 with a narrower value; the old line's excess
+   * bytes must not survive */
+  d = 3;
+  n = gd_putdata(D, "data", 0, 0, 0, 1, GD_INT32, &d);
+  CHECKI(n, 1);
+
+  memset(c, 0, sizeof(c));
+  n = (int)gd_getdata(D, "data", 0, 0, 2, 0, GD_INT32, c);
+  CHECKI(n, 2);
+  CHECKIi(0, c[0], 3);
+  CHECKIi(1, c[1], 2);
+  CHECKI(gd_eof64(D, "data"), 2);
+
+  e = gd_close(D);
+  CHECKI(e, 0);
+
+  unlink(data);
+  unlink(format);
+  rmdir(filedir);
+
+  return r;
+}

--- a/test/bzip_get_far.c
+++ b/test/bzip_get_far.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2014, 2017 D.V. Wiebe
+/* Copyright (C) 2026 G. Smecher
  *
  ***************************************************************************
  *
@@ -20,53 +20,16 @@
  */
 #include "test.h"
 
-int main(void)
-{
 #ifndef TEST_BZIP2
-  return 77;
-#else
-  const char *filedir = "dirfile";
-  const char *format = "dirfile/format";
-  const char *data = "dirfile/data";
-  const char *bz2data = "dirfile/data.bz2";
-  uint16_t c[8];
-  char command[4096];
-  int n, error, r = 0;
-  DIRFILE *D;
-
-  memset(c, 0, 8 * sizeof(*c));
-  rmdirfile();
-  mkdir(filedir, 0700);
-
-  MAKEFORMATFILE(format, "data RAW UINT16 8\n");
-  MAKEDATAFILE(data, uint16_t, i, 256);
-
-  /* compress */
-  snprintf(command, 4096, "\"%s\" -f %s > %s", BZIP2, data, NULL_DEVICE);
-  if (gd_system(command))
-    return 1;
+#define ENC_SKIP_TEST 1
+#endif
 
 #ifdef USE_BZIP2
-  D = gd_open(filedir, GD_RDONLY | GD_VERBOSE);
-#else
-  D = gd_open(filedir, GD_RDONLY);
+#define USE_ENC 1
 #endif
-  n = gd_getdata(D, "data", 1000, 0, 1, 0, GD_UINT16, c);
-  error = gd_error(D);
 
-  gd_discard(D);
+#define ENC_SUFFIX ".bz2"
+#define ENC_COMPRESS \
+  snprintf(command, 4096, "\"%s\" -f %s > %s", BZIP2, data, NULL_DEVICE)
 
-  unlink(bz2data);
-  unlink(format);
-  rmdir(filedir);
-
-#ifdef USE_BZIP2
-  CHECKI(error, 0);
-#else
-  CHECKI(error, GD_E_UNSUPPORTED);
-#endif
-  CHECKI(n, 0);
-
-  return r;
-#endif
-}
+#include "enc_get_far.c"

--- a/test/bzip_get_get.c
+++ b/test/bzip_get_get.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2008-2011, 2013, 2017 D.V. Wiebe
+/* Copyright (C) 2026 G. Smecher
  *
  ***************************************************************************
  *
@@ -20,58 +20,16 @@
  */
 #include "test.h"
 
-int main(void)
-{
-#if !defined USE_BZIP2 || !defined TEST_BZIP2
-  return 77; /* skip test */
-#else
-  const char *filedir = "dirfile";
-  const char *format = "dirfile/format";
-  const char *data = "dirfile/data";
-  const char *gzipdata = "dirfile/data.bz2";
-  uint16_t c1[8], c2[8];
-  char command[4096];
-  int i, n1, e1, e2, n2, e3, r = 0;
-  DIRFILE *D;
-
-  memset(c1, 0, 16);
-  memset(c2, 0, 16);
-  rmdirfile();
-  mkdir(filedir, 0700);
-
-  MAKEFORMATFILE(format, "data RAW UINT16 8\n");
-  MAKEDATAFILE(data, uint16_t, i, 256);
-
-  /* compress */
-  snprintf(command, 4096, "\"%s\" -f %s > %s", BZIP2, data, NULL_DEVICE);
-  if (gd_system(command))
-    return 1;
-
-  D = gd_open(filedir, GD_RDONLY | GD_VERBOSE);
-  n1 = gd_getdata(D, "data", 5, 0, 1, 0, GD_UINT16, c1);
-  CHECKI(n1, 8);
-  e1 = gd_error(D);
-  CHECKI(e1, 0);
-
-  e2 = gd_close(D);
-  CHECKI(e2, 0);
-
-  D = gd_open(filedir, GD_RDONLY | GD_VERBOSE);
-  n2 = gd_getdata(D, "data", 5, 0, 1, 0, GD_UINT16, c2);
-  e3 = gd_error(D);
-  CHECKI(e3, 0);
-  CHECKI(n2, 8);
-  for (i = 0; i < 8; ++i) {
-    CHECKIi(i,c1[i], 40 + i);
-    CHECKIi(i,c2[i], 40 + i);
-  }
-
-  gd_discard(D);
-
-  unlink(gzipdata);
-  unlink(format);
-  rmdir(filedir);
-
-  return r;
+#ifndef TEST_BZIP2
+#define ENC_SKIP_TEST 1
 #endif
-}
+
+#ifdef USE_BZIP2
+#define USE_ENC 1
+#endif
+
+#define ENC_SUFFIX ".bz2"
+#define ENC_COMPRESS \
+  snprintf(command, 4096, "\"%s\" -f %s > %s", BZIP2, data, NULL_DEVICE)
+
+#include "enc_get_get.c"

--- a/test/bzip_get_get2.c
+++ b/test/bzip_get_get2.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2014, 2017 D.V. Wiebe
+/* Copyright (C) 2026 G. Smecher
  *
  ***************************************************************************
  *
@@ -20,53 +20,16 @@
  */
 #include "test.h"
 
-int main(void)
-{
-#if !defined USE_BZIP2 || !defined TEST_BZIP2
-  return 77; /* skip test */
-#else
-  const char *filedir = "dirfile";
-  const char *format = "dirfile/format";
-  const char *data = "dirfile/data";
-  const char *bz2data = "dirfile/data.bz2";
-  uint16_t c1[8], c2[8];
-  char command[4096];
-  int i, n1, error1, n2, error2, r = 0;
-  DIRFILE *D;
-
-  memset(c1, 0, 16);
-  memset(c2, 0, 16);
-  rmdirfile();
-  mkdir(filedir, 0700);
-
-  MAKEFORMATFILE(format, "data RAW UINT16 8\n");
-  MAKEDATAFILE(data, uint16_t, i, 256);
-
-  /* compress */
-  snprintf(command, 4096, "\"%s\" -f %s > %s", BZIP2, data, NULL_DEVICE);
-  if (gd_system(command))
-    return 1;
-
-  D = gd_open(filedir, GD_RDONLY | GD_VERBOSE);
-  n1 = gd_getdata(D, "data", 0, 0, 1, 0, GD_UINT16, c1);
-  error1 = gd_error(D);
-  n2 = gd_getdata(D, "data", 0, 0, 1, 0, GD_UINT16, c2);
-  error2 = gd_error(D);
-  gd_discard(D);
-
-  unlink(bz2data);
-  unlink(format);
-  rmdir(filedir);
-
-  CHECKI(error1, 0);
-  CHECKI(error2, 0);
-  CHECKI(n1, 8);
-  CHECKI(n2, 8);
-  for (i = 0; i < 8; ++i) {
-    CHECKUi(i,c1[i], i);
-    CHECKUi(i,c2[i], i);
-  }
-
-  return r;
+#ifndef TEST_BZIP2
+#define ENC_SKIP_TEST 1
 #endif
-}
+
+#ifdef USE_BZIP2
+#define USE_ENC 1
+#endif
+
+#define ENC_SUFFIX ".bz2"
+#define ENC_COMPRESS \
+  snprintf(command, 4096, "\"%s\" -f %s > %s", BZIP2, data, NULL_DEVICE)
+
+#include "enc_get_get2.c"

--- a/test/bzip_move_to.c
+++ b/test/bzip_move_to.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2014, 2017 D.V. Wiebe
+/* Copyright (C) 2026 G. Smecher
  *
  ***************************************************************************
  *
@@ -20,89 +20,17 @@
  */
 #include "test.h"
 
-int main(void)
-{
-  const char *filedir = "dirfile";
-  const char *format = "dirfile/format";
-  const char *data_bz2 = "dirfile/data.bz2";
-  const char *data_raw = "dirfile/data";
-  uint8_t data_in[256];
-  DIRFILE *D;
-#ifdef USE_BZIP2
-  uint8_t d;
-  char command[4096];
-  int i;
-#endif
-  int fd, e1, e2, unlink_raw, r = 0;
-  struct stat buf;
-
-  rmdirfile();
-  mkdir(filedir, 0700); 
-
-  for (fd = 0; fd < 256; ++fd)
-    data_in[fd] = (unsigned char)fd;
-
-  MAKEFORMATFILE(format, "data RAW UINT8 8\n/ENCODING none\n/ENDIAN little\n");
-
-  fd = open(data_raw, O_CREAT | O_EXCL | O_WRONLY | O_BINARY, 0666);
-  write(fd, data_in, 256);
-  close(fd);
-
-#ifdef USE_BZIP2
-  D = gd_open(filedir, GD_RDWR | GD_VERBOSE);
-#else
-  D = gd_open(filedir, GD_RDWR);
-#endif
-  gd_alter_encoding(D, GD_BZIP2_ENCODED, 0, 1);
-  e1 = gd_error(D);
-
-  e2 = gd_close(D);
-  CHECKI(e2, 0);
-
-#ifdef USE_BZIP2
-  if (stat(data_bz2, &buf)) {
-    perror("stat");
-    r = 1;
-  }
-  CHECKI(stat(data_raw, &buf), -1);
-#else
-  if (stat(data_raw, &buf)) {
-    perror("stat");
-    r = 1;
-  }
-  CHECKI(stat(data_bz2, &buf), -1);
+#ifndef TEST_BZIP2
+#define ENC_SKIP_TEST 1
 #endif
 
 #ifdef USE_BZIP2
-  /* uncompress */
-  snprintf(command, 4096, "\"%s\" -df %s > %s", BZIP2, data_bz2, NULL_DEVICE);
-  if (gd_system(command)) {
-    fprintf(stderr, "command failed: %s\n", command);
-    r = 1;
-  } else {
-    fd = open(data_raw, O_RDONLY | O_BINARY);
-    if (fd >= 0) {
-      i = 0;
-      while (read(fd, &d, sizeof(uint8_t))) {
-        CHECKIi(i, d, i);
-        i++;
-      }
-      CHECKI(i, 256);
-      close(fd);
-    }
-  }
+#define USE_ENC 1
 #endif
 
-  unlink_raw = unlink(data_raw);
-  unlink(format);
-  rmdir(filedir);
+#define ENC_SUFFIX ".bz2"
+#define ENC_ENCODING GD_BZIP2_ENCODED
+#define ENC_COMPRESS \
+  snprintf(command, 4096, "\"%s\" -df %s > %s", BZIP2, encdata, NULL_DEVICE)
 
-  CHECKI(unlink_raw, 0);
-#ifdef USE_BZIP2
-  CHECKI(e1, GD_E_OK);
-#else
-  CHECKI(e1, GD_E_UNSUPPORTED);
-#endif
-
-  return r;
-}
+#include "enc_move_to.c"

--- a/test/bzip_put.c
+++ b/test/bzip_put.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2014, 2017 D.V. Wiebe
+/* Copyright (C) 2026 G. Smecher
  *
  ***************************************************************************
  *
@@ -20,92 +20,17 @@
  */
 #include "test.h"
 
-int main(void)
-{
 #ifndef TEST_BZIP2
-  return 77;
-#else
-  const char *filedir = "dirfile";
-  const char *format = "dirfile/format";
-  const char *data_bz2 = "dirfile/data.bz2";
-  const char *data = "dirfile/data";
-  uint8_t c[8];
-#ifdef USE_BZIP2
-  char command[4096];
-  uint8_t d;
-#endif
-  struct stat buf;
-  int fd, i, n, e1, e2, stat_data, unlink_data, unlink_bz2, r = 0;
-  DIRFILE *D;
-
-  rmdirfile();
-  mkdir(filedir, 0700);
-
-  for (i = 0; i < 8; ++i)
-    c[i] = (uint8_t)(40 + i);
-
-  MAKEFORMATFILE(format, "data RAW UINT8 8\n");
-
-#ifdef USE_BZIP2
-  D = gd_open(filedir, GD_RDWR | GD_BZIP2_ENCODED | GD_VERBOSE);
-#else
-  D = gd_open(filedir, GD_RDWR | GD_BZIP2_ENCODED);
-#endif
-  n = gd_putdata(D, "data", 5, 0, 1, 0, GD_UINT8, c);
-  e1 = gd_error(D);
-
-  e2 = gd_close(D);
-  CHECKI(e2, 0);
-
-  stat_data = stat(data_bz2, &buf);
-#ifdef USE_BZIP2
-  if (stat_data) {
-    perror("stat");
-  }
-  CHECKI(stat_data, 0);
-#else
-  CHECKI(stat_data, -1);
+#define ENC_SKIP_TEST 1
 #endif
 
 #ifdef USE_BZIP2
-  /* uncompress */
-  snprintf(command, 4096, "\"%s\" -df %s > %s", BZIP2, data_bz2, NULL_DEVICE);
-  if (gd_system(command)) {
-    r = 1;
-  } else {
-    fd = open(data, O_RDONLY | O_BINARY);
-    if (fd >= 0) {
-      i = 0;
-      while (read(fd, &d, sizeof(uint8_t))) {
-        if (i < 40 || i > 48) {
-          CHECKIi(i, d, 0);
-        } else
-          CHECKIi(i, d, i);
-        i++;
-      }
-      CHECKI(i, 48);
-      close(fd);
-    }
-  }
+#define USE_ENC 1
 #endif
 
-  unlink_bz2 = unlink(data_bz2);
-  CHECKI(unlink_bz2, -1);
+#define ENC_SUFFIX ".bz2"
+#define ENC_ENCODING GD_BZIP2_ENCODED
+#define ENC_COMPRESS \
+  snprintf(command, 4096, "\"%s\" -df %s > %s", BZIP2, encdata, NULL_DEVICE)
 
-  unlink_data = unlink(data);
-  unlink(format);
-  rmdir(filedir);
-
-#ifdef USE_BZIP2
-  CHECKI(unlink_data, 0);
-  CHECKI(e1, GD_E_OK);
-  CHECKI(n, 8);
-#else
-  CHECKI(unlink_data, -1);
-  CHECKI(e1, GD_E_UNSUPPORTED);
-  CHECKI(n, 0);
-#endif
-
-  return r;
-#endif
-}
+#include "enc_put.c"

--- a/test/bzip_put_back.c
+++ b/test/bzip_put_back.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2014, 2017 D.V. Wiebe
+/* Copyright (C) 2026 G. Smecher
  *
  ***************************************************************************
  *
@@ -20,78 +20,17 @@
  */
 #include "test.h"
 
-int main(void)
-{
-#if ! (defined TEST_BZIP2) || ! (defined USE_BZIP2)
-  return 77;
-#else
-  const char *filedir = "dirfile";
-  const char *format = "dirfile/format";
-  const char *data_bz2 = "dirfile/data.bz2";
-  const char *data = "dirfile/data";
-  uint8_t c[8];
-  char command[4096];
-  uint8_t d;
-  struct stat buf;
-  int fd, i, n1, n2, e1, e2, e3, stat_data, unlink_data, r = 0;
-  DIRFILE *D;
-
-  rmdirfile();
-  mkdir(filedir, 0700);
-
-  for (i = 0; i < 8; ++i)
-    c[i] = (uint8_t)(40 + i);
-
-  MAKEFORMATFILE(format, "data RAW UINT8 8\n");
-
-  D = gd_open(filedir, GD_RDWR | GD_BZIP2_ENCODED | GD_VERBOSE);
-  n1 = gd_putdata(D, "data", 5, 0, 1, 0, GD_UINT8, c);
-  e1 = gd_error(D);
-  CHECKI(e1, GD_E_OK);
-  CHECKI(n1, 8);
-
-  n2 = gd_putdata(D, "data", 0, 0, 1, 0, GD_UINT8, c);
-  e2 = gd_error(D);
-  CHECKI(e2, GD_E_OK);
-  CHECKI(n2, 8);
-
-  e3 = gd_close(D);
-  CHECKI(e3, 0);
-
-  stat_data = stat(data_bz2, &buf);
-  if (stat_data) {
-    perror("stat");
-  }
-  CHECKI(stat_data, 0);
-
-  /* uncompress */
-  snprintf(command, 4096, "\"%s\" -df %s > %s", BZIP2, data_bz2, NULL_DEVICE);
-  if (gd_system(command)) {
-    r = 1;
-  } else {
-    fd = open(data, O_RDONLY | O_BINARY);
-    if (fd >= 0) {
-      i = 0;
-      while (read(fd, &d, sizeof(uint8_t))) {
-        if (i < 8) {
-          CHECKIi(i, d, i + 40);
-        } else if (i < 40 || i > 48) {
-          CHECKIi(i, d, 0);
-        } else
-          CHECKIi(i, d, i);
-        i++;
-      }
-      CHECKI(i, 48);
-      close(fd);
-    }
-  }
-
-  unlink_data = unlink(data);
-  unlink(format);
-  rmdir(filedir);
-
-  CHECKI(unlink_data, 0);
-
-  return r;
+#ifndef TEST_BZIP2
+#define ENC_SKIP_TEST 1
 #endif
-}
+
+#ifdef USE_BZIP2
+#define USE_ENC 1
+#endif
+
+#define ENC_SUFFIX ".bz2"
+#define ENC_ENCODING GD_BZIP2_ENCODED
+#define ENC_COMPRESS \
+  snprintf(command, 4096, "\"%s\" -df %s > %s", BZIP2, encdata, NULL_DEVICE)
+
+#include "enc_put_back.c"

--- a/test/bzip_put_endian.c
+++ b/test/bzip_put_endian.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2014, 2017 D.V. Wiebe
+/* Copyright (C) 2026 G. Smecher
  *
  ***************************************************************************
  *
@@ -20,95 +20,17 @@
  */
 #include "test.h"
 
-#ifdef WORDS_BIGENDIAN
-#define ENDIAN "ENDIAN little"
-#else
-#define ENDIAN "ENDIAN big"
-#endif
-
-int main(void)
-{
 #ifndef TEST_BZIP2
-  return 77;
-#else
-  const char *filedir = "dirfile";
-  const char *format = "dirfile/format";
-  const char *data_bz2 = "dirfile/data.bz2";
-  const char *data = "dirfile/data";
-  uint16_t c[8];
-#ifdef USE_BZIP2
-  char command[4096];
-  uint16_t d;
-#endif
-  struct stat buf;
-  int fd, i, n, e1, e2, stat_data, unlink_data, r = 0;
-  DIRFILE *D;
-
-  rmdirfile();
-  mkdir(filedir, 0700);
-
-  for (i = 0; i < 8; ++i)
-    c[i] = (uint16_t)(0x102 * i);
-
-  MAKEFORMATFILE(format, "data RAW UINT16 8\n" ENDIAN "\n");
-
-#ifdef USE_BZIP2
-  D = gd_open(filedir, GD_RDWR | GD_BZIP2_ENCODED | GD_VERBOSE);
-#else
-  D = gd_open(filedir, GD_RDWR | GD_BZIP2_ENCODED);
-#endif
-  n = gd_putdata(D, "data", 5, 0, 1, 0, GD_UINT16, c);
-  e1 = gd_error(D);
-
-  e2 = gd_close(D);
-  CHECKI(e2, 0);
-
-  stat_data = stat(data_bz2, &buf);
-#ifdef USE_BZIP2
-  if (stat_data) {
-    perror("stat");
-  }
-  CHECKI(stat_data, 0);
-#else
-  CHECKI(stat_data, -1);
+#define ENC_SKIP_TEST 1
 #endif
 
 #ifdef USE_BZIP2
-  /* uncompress */
-  snprintf(command, 4096, "\"%s\" -df %s > %s", BZIP2, data_bz2, NULL_DEVICE);
-  if (gd_system(command)) {
-    r = 1;
-  } else {
-    fd = open(data, O_RDONLY | O_BINARY);
-    if (fd >= 0) {
-      i = 0;
-      while (read(fd, &d, sizeof(uint16_t))) {
-        if (i < 40 || i > 48) {
-          CHECKIi(i, d, 0);
-        } else
-          CHECKIi(i, d, 0x201 * (i - 40));
-        i++;
-      }
-      CHECKI(i, 48);
-      close(fd);
-    }
-  }
+#define USE_ENC 1
 #endif
 
-  unlink_data = unlink(data);
-  unlink(format);
-  rmdir(filedir);
+#define ENC_SUFFIX ".bz2"
+#define ENC_ENCODING GD_BZIP2_ENCODED
+#define ENC_COMPRESS \
+  snprintf(command, 4096, "\"%s\" -df %s > %s", BZIP2, encdata, NULL_DEVICE)
 
-#ifdef USE_BZIP2
-  CHECKI(unlink_data, 0);
-  CHECKI(e1, GD_E_OK);
-  CHECKI(n, 8);
-#else
-  CHECKI(unlink_data, -1);
-  CHECKI(e1, GD_E_UNSUPPORTED);
-  CHECKI(n, 0);
-#endif
-
-  return r;
-#endif
-}
+#include "enc_put_endian.c"

--- a/test/bzip_put_get.c
+++ b/test/bzip_put_get.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2014, 2017 D.V. Wiebe
+/* Copyright (C) 2026 G. Smecher
  *
  ***************************************************************************
  *
@@ -20,60 +20,15 @@
  */
 #include "test.h"
 
-int main(void)
-{
 #ifndef TEST_BZIP2
-  return 77;
-#else
-  const char *filedir = "dirfile";
-  const char *format = "dirfile/format";
-  const char *data = "dirfile/data.bz2";
-  uint8_t c[8], d[8];
-  int i, m, n, e1, e2, e3, unlink_data, r = 0;
-  DIRFILE *D;
-
-  rmdirfile();
-  mkdir(filedir, 0700);
-
-  for (i = 0; i < 8; ++i)
-    c[i] = (uint8_t)(40 + i);
-
-  MAKEFORMATFILE(format, "data RAW UINT8 8\n");
+#define ENC_SKIP_TEST 1
+#endif
 
 #ifdef USE_BZIP2
-  D = gd_open(filedir, GD_RDWR | GD_BZIP2_ENCODED | GD_VERBOSE);
-#else
-  D = gd_open(filedir, GD_RDWR | GD_BZIP2_ENCODED);
+#define USE_ENC 1
 #endif
-  n = gd_putdata(D, "data", 5, 0, 1, 0, GD_UINT8, c);
-  e1 = gd_error(D);
-  m = gd_getdata(D, "data", 5, 0, 1, 0, GD_UINT8, d);
-  e2 = gd_error(D);
 
-  for (i = 0; i < m; ++i)
-    CHECKIi(i, d[i], c[i]);
+#define ENC_SUFFIX ".bz2"
+#define ENC_ENCODING GD_BZIP2_ENCODED
 
-  e3 = gd_close(D);
-  CHECKI(e3, 0);
-
-  unlink_data = unlink(data);
-  unlink(format);
-  rmdir(filedir);
-
-#ifdef USE_BZIP2
-  CHECKI(unlink_data, 0);
-  CHECKI(e1, GD_E_OK);
-  CHECKI(e2, GD_E_OK);
-  CHECKI(n, 8);
-  CHECKI(m, 8);
-#else
-  CHECKI(unlink_data, -1);
-  CHECKI(e1, GD_E_UNSUPPORTED);
-  CHECKI(e2, GD_E_UNSUPPORTED);
-  CHECKI(n, 0);
-  CHECKI(m, 0);
-#endif
-  
-  return r;
-#endif
-}
+#include "enc_put_get.c"

--- a/test/bzip_put_nframes.c
+++ b/test/bzip_put_nframes.c
@@ -20,15 +20,11 @@
  */
 #include "test.h"
 
-#ifndef TEST_LZMA
-#define ENC_SKIP_TEST 1
-#endif
-
-#ifdef USE_LZMA
+#ifdef USE_BZIP2
 #define USE_ENC 1
 #endif
 
-#define ENC_SUFFIX ".xz"
-#define ENC_ENCODING GD_LZMA_ENCODED
+#define ENC_SUFFIX ".bz2"
+#define ENC_ENCODING GD_BZIP2_ENCODED
 
-#include "enc_put_get.c"
+#include "enc_put_nframes.c"

--- a/test/bzip_put_pad.c
+++ b/test/bzip_put_pad.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2014, 2017 D.V. Wiebe
+/* Copyright (C) 2026 G. Smecher
  *
  ***************************************************************************
  *
@@ -20,80 +20,17 @@
  */
 #include "test.h"
 
-int main(void)
-{
-#if ! (defined TEST_BZIP2) || ! (defined USE_BZIP2)
-  return 77;
-#else
-  const char *filedir = "dirfile";
-  const char *format = "dirfile/format";
-  const char *data_bz2 = "dirfile/data.bz2";
-  const char *data = "dirfile/data";
-  uint8_t c[8];
-  char command[4096];
-  uint8_t d;
-  struct stat buf;
-  int fd, i, n1, n2, e1, e2, e3, stat_data, unlink_data, r = 0;
-  DIRFILE *D;
-
-  rmdirfile();
-  mkdir(filedir, 0700);
-
-  for (i = 0; i < 8; ++i)
-    c[i] = (uint8_t)(40 + i);
-
-  MAKEFORMATFILE(format, "data RAW UINT8 8\n");
-
-  D = gd_open(filedir, GD_RDWR | GD_BZIP2_ENCODED | GD_VERBOSE);
-  n1 = gd_putdata(D, "data", 0, 0, 1, 0, GD_UINT8, c);
-  e1 = gd_error(D);
-  CHECKI(e1, GD_E_OK);
-  CHECKI(n1, 8);
-  gd_close(D);
-
-  D = gd_open(filedir, GD_RDWR | GD_BZIP2_ENCODED | GD_VERBOSE);
-  n2 = gd_putdata(D, "data", 5, 0, 1, 0, GD_UINT8, c);
-  e2 = gd_error(D);
-  CHECKI(e2, GD_E_OK);
-  CHECKI(n2, 8);
-
-  e3 = gd_close(D);
-  CHECKI(e3, 0);
-
-  stat_data = stat(data_bz2, &buf);
-  if (stat_data) {
-    perror("stat");
-  }
-  CHECKI(stat_data, 0);
-
-  /* uncompress */
-  snprintf(command, 4096, "\"%s\" -df %s > %s", BZIP2, data_bz2, NULL_DEVICE);
-  if (gd_system(command)) {
-    r = 1;
-  } else {
-    fd = open(data, O_RDONLY | O_BINARY);
-    if (fd >= 0) {
-      i = 0;
-      while (read(fd, &d, sizeof(uint8_t))) {
-        if (i < 8) {
-          CHECKIi(i, d, i + 40);
-        } else if (i < 40 || i > 48) {
-          CHECKIi(i, d, 0);
-        } else
-          CHECKIi(i, d, i);
-        i++;
-      }
-      CHECKI(i, 48);
-      close(fd);
-    }
-  }
-
-  unlink_data = unlink(data);
-  unlink(format);
-  rmdir(filedir);
-
-  CHECKI(unlink_data, 0);
-
-  return r;
+#ifndef TEST_BZIP2
+#define ENC_SKIP_TEST 1
 #endif
-}
+
+#ifdef USE_BZIP2
+#define USE_ENC 1
+#endif
+
+#define ENC_SUFFIX ".bz2"
+#define ENC_ENCODING GD_BZIP2_ENCODED
+#define ENC_COMPRESS \
+  snprintf(command, 4096, "\"%s\" -df %s > %s", BZIP2, encdata, NULL_DEVICE)
+
+#include "enc_put_pad.c"

--- a/test/bzip_put_sub.c
+++ b/test/bzip_put_sub.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2014, 2017 D.V. Wiebe
+/* Copyright (C) 2026 G. Smecher
  *
  ***************************************************************************
  *
@@ -20,84 +20,17 @@
  */
 #include "test.h"
 
-int main(void)
-{
-#if ! (defined TEST_BZIP2) || ! (defined USE_BZIP2)
-  return 77;
-#else
-  const char *filedir = "dirfile";
-  const char *subdir = "dirfile/sub";
-  const char *format = "dirfile/format";
-  const char *format1 = "dirfile/sub/format1";
-  const char *data_bz2 = "dirfile/sub/data.bz2";
-  const char *data = "dirfile/sub/data";
-  uint8_t c[8];
-  char command[4096];
-  uint8_t d;
-  struct stat buf;
-  int fd, i, n1, n2, e1, e2, e3, stat_data, unlink_data, r = 0;
-  DIRFILE *D;
-
-  rmdirfile();
-  mkdir(filedir, 0700);
-  mkdir(subdir, 0700);
-
-  for (i = 0; i < 8; ++i)
-    c[i] = (uint8_t)(40 + i);
-
-  MAKEFORMATFILE(format, "/INCLUDE sub/format1\n");
-  MAKEFORMATFILE(format1, "data RAW UINT8 8\n");
-
-  D = gd_open(filedir, GD_RDWR | GD_BZIP2_ENCODED | GD_VERBOSE);
-  n1 = gd_putdata(D, "data", 5, 0, 1, 0, GD_UINT8, c);
-  e1 = gd_error(D);
-  CHECKI(e1, GD_E_OK);
-  CHECKI(n1, 8);
-
-  n2 = gd_putdata(D, "data", 0, 0, 1, 0, GD_UINT8, c);
-  e2 = gd_error(D);
-  CHECKI(e2, GD_E_OK);
-  CHECKI(n2, 8);
-
-  e3 = gd_close(D);
-  CHECKI(e3, 0);
-
-  stat_data = stat(data_bz2, &buf);
-  if (stat_data) {
-    perror("stat");
-  }
-  CHECKI(stat_data, 0);
-
-  /* uncompress */
-  snprintf(command, 4096, "\"%s\" -df %s > %s", BZIP2, data_bz2, NULL_DEVICE);
-  if (gd_system(command)) {
-    r = 1;
-  } else {
-    fd = open(data, O_RDONLY | O_BINARY);
-    if (fd >= 0) {
-      i = 0;
-      while (read(fd, &d, sizeof(uint8_t))) {
-        if (i < 8) {
-          CHECKIi(i, d, i + 40);
-        } else if (i < 40 || i > 48) {
-          CHECKIi(i, d, 0);
-        } else
-          CHECKIi(i, d, i);
-        i++;
-      }
-      CHECKI(i, 48);
-      close(fd);
-    }
-  }
-
-  unlink_data = unlink(data);
-  unlink(format1);
-  unlink(format);
-  rmdir(subdir);
-  rmdir(filedir);
-
-  CHECKI(unlink_data, 0);
-
-  return r;
+#ifndef TEST_BZIP2
+#define ENC_SKIP_TEST 1
 #endif
-}
+
+#ifdef USE_BZIP2
+#define USE_ENC 1
+#endif
+
+#define ENC_SUFFIX ".bz2"
+#define ENC_ENCODING GD_BZIP2_ENCODED
+#define ENC_COMPRESS \
+  snprintf(command, 4096, "\"%s\" -df %s > %s", BZIP2, encdata, NULL_DEVICE)
+
+#include "enc_put_sub.c"

--- a/test/bzip_sync.c
+++ b/test/bzip_sync.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2014, 2017 D.V. Wiebe
+/* Copyright (C) 2026 G. Smecher
  *
  ***************************************************************************
  *
@@ -20,70 +20,17 @@
  */
 #include "test.h"
 
-int main(void)
-{
-#if !defined TEST_BZIP2 || !defined USE_BZIP2
-  return 77;
-#else
-  const char *filedir = "dirfile";
-  const char *format = "dirfile/format";
-  const char *data_bz2 = "dirfile/data.bz2";
-  const char *data = "dirfile/data";
-  uint8_t c[8];
-  char command[4096];
-  uint8_t d;
-  struct stat buf;
-  int fd, i, n, e1, e2, stat_data, r = 0;
-  DIRFILE *D;
-
-  rmdirfile();
-  mkdir(filedir, 0700);
-
-  for (i = 0; i < 8; ++i)
-    c[i] = (uint8_t)(40 + i);
-
-  MAKEFORMATFILE(format, "data RAW UINT8 8\n");
-
-  D = gd_open(filedir, GD_RDWR | GD_BZIP2_ENCODED | GD_VERBOSE);
-  gd_putdata(D, "data", 5, 0, 1, 0, GD_UINT8, c);
-  n = gd_flush(D, "data");
-  e1 = gd_error(D);
-  CHECKI(e1, GD_E_OK);
-  CHECKI(n, 0);
-
-  e2 = gd_close(D);
-  CHECKI(e2, 0);
-
-  stat_data = stat(data_bz2, &buf);
-  if (stat_data) {
-    perror("stat");
-  }
-  CHECKI(stat_data, 0);
-
-  /* uncompress */
-  snprintf(command, 4096, "\"%s\" -df %s > %s", BZIP2, data_bz2, NULL_DEVICE);
-  if (gd_system(command)) {
-    r = 1;
-  } else {
-    fd = open(data, O_RDONLY | O_BINARY);
-    if (fd >= 0) {
-      i = 0;
-      while (read(fd, &d, sizeof(uint8_t))) {
-        if (i < 40 || i > 48) {
-          CHECKIi(i, d, 0);
-        } else
-          CHECKIi(i, d, i);
-        i++;
-      }
-      CHECKI(i, 48);
-      close(fd);
-    }
-  }
-
-  unlink(data);
-  unlink(format);
-  rmdir(filedir);
-
-  return r;
+#ifndef TEST_BZIP2
+#define ENC_SKIP_TEST 1
 #endif
-}
+
+#ifdef USE_BZIP2
+#define USE_ENC 1
+#endif
+
+#define ENC_SUFFIX ".bz2"
+#define ENC_ENCODING GD_BZIP2_ENCODED
+#define ENC_COMPRESS \
+  snprintf(command, 4096, "\"%s\" -df %s > %s", BZIP2, encdata, NULL_DEVICE)
+
+#include "enc_sync.c"

--- a/test/enc_get_far.c
+++ b/test/enc_get_far.c
@@ -1,0 +1,72 @@
+/* Copyright (C) 2014, 2017 D.V. Wiebe
+ *
+ ***************************************************************************
+ *
+ * This file is part of the GetData project.
+ *
+ * GetData is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the
+ * Free Software Foundation; either version 2.1 of the License, or (at your
+ * option) any later version.
+ *
+ * GetData is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with GetData; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+#include "test.h"
+
+int main(void)
+{
+#ifdef ENC_SKIP_TEST
+  return 77;
+#else
+  const char *filedir = "dirfile";
+  const char *format = "dirfile/format";
+  const char *data = "dirfile/data";
+  const char *encdata = "dirfile/data" ENC_SUFFIX;
+  uint16_t c[8];
+  char command[4096];
+  int n, error, r = 0;
+  DIRFILE *D;
+
+  memset(c, 0, 8 * sizeof(*c));
+  rmdirfile();
+  mkdir(filedir, 0700);
+
+  MAKEFORMATFILE(format, "data RAW UINT16 8\n");
+  MAKEDATAFILE(data, uint16_t, i, 256);
+
+  /* compress */
+  ENC_COMPRESS;
+  if (gd_system(command))
+    return 1;
+
+#ifdef USE_ENC
+  D = gd_open(filedir, GD_RDONLY | GD_VERBOSE);
+#else
+  D = gd_open(filedir, GD_RDONLY);
+#endif
+  n = gd_getdata(D, "data", 1000, 0, 1, 0, GD_UINT16, c);
+  error = gd_error(D);
+
+  gd_discard(D);
+
+  unlink(encdata);
+  unlink(format);
+  rmdir(filedir);
+
+#ifdef USE_ENC
+  CHECKI(error, 0);
+#else
+  CHECKI(error, GD_E_UNSUPPORTED);
+#endif
+  CHECKI(n, 0);
+
+  return r;
+#endif
+}

--- a/test/enc_get_get.c
+++ b/test/enc_get_get.c
@@ -1,0 +1,82 @@
+/* Copyright (C) 2015, 2017 D. V. Wiebe
+ *
+ ***************************************************************************
+ *
+ * This file is part of the GetData project.
+ *
+ * GetData is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the
+ * Free Software Foundation; either version 2.1 of the License, or (at your
+ * option) any later version.
+ *
+ * GetData is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with GetData; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+#include "test.h"
+
+int main(void)
+{
+#if !defined USE_ENC || !!defined ENC_SKIP_TEST
+  return 77; /* skip test */
+#else
+  const char *filedir = "dirfile";
+  const char *format = "dirfile/format";
+  const char *data = "dirfile/data";
+  const char *encdata = "dirfile/data" ENC_SUFFIX;
+  uint16_t c1[8], c2[8];
+  char command[4096];
+  int i, n1, e1, e2, n2, e3, r = 0;
+  DIRFILE *D;
+
+  memset(c1, 0, 16);
+  memset(c2, 0, 16);
+  rmdirfile();
+  mkdir(filedir, 0700);
+
+  MAKEFORMATFILE(format, "data RAW UINT16 8\n");
+  MAKEDATAFILE(data, uint16_t, i, 256);
+
+#ifdef WORDS_BIGENDIAN
+#define ENDIANNESS "--endian=big"
+#else
+#define ENDIANNESS "--endian=little"
+#endif
+
+  ENC_COMPRESS;
+  if (gd_system(command))
+    return 1;
+
+  D = gd_open(filedir, GD_RDONLY | GD_VERBOSE);
+  n1 = gd_getdata(D, "data", 5, 0, 1, 0, GD_UINT16, c1);
+  CHECKI(n1, 8);
+  e1 = gd_error(D);
+  CHECKI(e1, 0);
+
+  e2 = gd_close(D);
+  CHECKI(e2, 0);
+
+  D = gd_open(filedir, GD_RDONLY | GD_VERBOSE);
+  n2 = gd_getdata(D, "data", 5, 0, 1, 0, GD_UINT16, c2);
+  e3 = gd_error(D);
+  CHECKI(e3, 0);
+  CHECKI(n2, 8);
+  for (i = 0; i < 8; ++i) {
+    CHECKIi(i,c1[i], 40 + i);
+    CHECKIi(i,c2[i], 40 + i);
+  }
+
+  gd_discard(D);
+
+  unlink(encdata);
+  unlink(format);
+  rmdir(filedir);
+
+  return r;
+#endif
+}

--- a/test/enc_get_get2.c
+++ b/test/enc_get_get2.c
@@ -1,0 +1,78 @@
+/* Copyright (C) 2015, 2017 D. V. Wiebe
+ *
+ ***************************************************************************
+ *
+ * This file is part of the GetData project.
+ *
+ * GetData is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the
+ * Free Software Foundation; either version 2.1 of the License, or (at your
+ * option) any later version.
+ *
+ * GetData is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with GetData; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+#include "test.h"
+
+int main(void)
+{
+#if !defined USE_ENC || !!defined ENC_SKIP_TEST
+  return 77; /* skip test */
+#else
+  const char *filedir = "dirfile";
+  const char *format = "dirfile/format";
+  const char *data = "dirfile/data";
+  const char *encdata = "dirfile/data" ENC_SUFFIX;
+  uint16_t c1[8], c2[8];
+  char command[4096];
+  int i, n1, error1, n2, error2, r = 0;
+  DIRFILE *D;
+
+  memset(c1, 0, 16);
+  memset(c2, 0, 16);
+  rmdirfile();
+  mkdir(filedir, 0700);
+
+  MAKEFORMATFILE(format, "data RAW UINT16 8\n");
+  MAKEDATAFILE(data, uint16_t, i, 256);
+
+#ifdef WORDS_BIGENDIAN
+#define ENDIANNESS "--endian=big"
+#else
+#define ENDIANNESS "--endian=little"
+#endif
+
+  /* compress */
+  ENC_COMPRESS;
+  if (gd_system(command))
+    return 1;
+
+  D = gd_open(filedir, GD_RDONLY | GD_VERBOSE);
+  n1 = gd_getdata(D, "data", 0, 0, 1, 0, GD_UINT16, c1);
+  error1 = gd_error(D);
+  n2 = gd_getdata(D, "data", 0, 0, 1, 0, GD_UINT16, c2);
+  error2 = gd_error(D);
+  gd_discard(D);
+
+  unlink(encdata);
+  unlink(format);
+  rmdir(filedir);
+
+  CHECKI(error1, 0);
+  CHECKI(error2, 0);
+  CHECKI(n1, 8);
+  CHECKI(n2, 8);
+  for (i = 0; i < 8; ++i) {
+    CHECKUi(i,c1[i], i);
+    CHECKUi(i,c2[i], i);
+  }
+
+  return r;
+#endif
+}

--- a/test/enc_move_to.c
+++ b/test/enc_move_to.c
@@ -1,0 +1,108 @@
+/* Copyright (C) 2014, 2017 D.V. Wiebe
+ *
+ ***************************************************************************
+ *
+ * This file is part of the GetData project.
+ *
+ * GetData is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the
+ * Free Software Foundation; either version 2.1 of the License, or (at your
+ * option) any later version.
+ *
+ * GetData is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with GetData; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+#include "test.h"
+
+int main(void)
+{
+  const char *filedir = "dirfile";
+  const char *format = "dirfile/format";
+  const char *encdata = "dirfile/data" ENC_SUFFIX;
+  const char *data_raw = "dirfile/data";
+  uint8_t data_in[256];
+  DIRFILE *D;
+#ifdef USE_ENC
+  uint8_t d;
+  char command[4096];
+  int i;
+#endif
+  int fd, e1, e2, unlink_raw, r = 0;
+  struct stat buf;
+
+  rmdirfile();
+  mkdir(filedir, 0700); 
+
+  for (fd = 0; fd < 256; ++fd)
+    data_in[fd] = (unsigned char)fd;
+
+  MAKEFORMATFILE(format, "data RAW UINT8 8\n/ENCODING none\n/ENDIAN little\n");
+
+  fd = open(data_raw, O_CREAT | O_EXCL | O_WRONLY | O_BINARY, 0666);
+  write(fd, data_in, 256);
+  close(fd);
+
+#ifdef USE_ENC
+  D = gd_open(filedir, GD_RDWR | GD_VERBOSE);
+#else
+  D = gd_open(filedir, GD_RDWR);
+#endif
+  gd_alter_encoding(D, ENC_ENCODING, 0, 1);
+  e1 = gd_error(D);
+
+  e2 = gd_close(D);
+  CHECKI(e2, 0);
+
+#ifdef USE_ENC
+  if (stat(encdata, &buf)) {
+    perror("stat");
+    r = 1;
+  }
+  CHECKI(stat(data_raw, &buf), -1);
+#else
+  if (stat(data_raw, &buf)) {
+    perror("stat");
+    r = 1;
+  }
+  CHECKI(stat(encdata, &buf), -1);
+#endif
+
+#ifdef USE_ENC
+  /* uncompress */
+  ENC_COMPRESS;
+  if (gd_system(command)) {
+    fprintf(stderr, "command failed: %s\n", command);
+    r = 1;
+  } else {
+    fd = open(data_raw, O_RDONLY | O_BINARY);
+    if (fd >= 0) {
+      i = 0;
+      while (read(fd, &d, sizeof(uint8_t))) {
+        CHECKIi(i, d, i);
+        i++;
+      }
+      CHECKI(i, 256);
+      close(fd);
+    }
+  }
+#endif
+
+  unlink_raw = unlink(data_raw);
+  unlink(format);
+  rmdir(filedir);
+
+  CHECKI(unlink_raw, 0);
+#ifdef USE_ENC
+  CHECKI(e1, GD_E_OK);
+#else
+  CHECKI(e1, GD_E_UNSUPPORTED);
+#endif
+
+  return r;
+}

--- a/test/enc_put.c
+++ b/test/enc_put.c
@@ -1,0 +1,111 @@
+/* Copyright (C) 2014, 2017 D.V. Wiebe
+ *
+ ***************************************************************************
+ *
+ * This file is part of the GetData project.
+ *
+ * GetData is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the
+ * Free Software Foundation; either version 2.1 of the License, or (at your
+ * option) any later version.
+ *
+ * GetData is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with GetData; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+#include "test.h"
+
+int main(void)
+{
+#ifdef ENC_SKIP_TEST
+  return 77;
+#else
+  const char *filedir = "dirfile";
+  const char *format = "dirfile/format";
+  const char *encdata = "dirfile/data" ENC_SUFFIX;
+  const char *data = "dirfile/data";
+  uint8_t c[8];
+#ifdef USE_ENC
+  char command[4096];
+  uint8_t d;
+#endif
+  struct stat buf;
+  int fd, i, n, e1, e2, stat_data, unlink_data, unlink_enc, r = 0;
+  DIRFILE *D;
+
+  rmdirfile();
+  mkdir(filedir, 0700);
+
+  for (i = 0; i < 8; ++i)
+    c[i] = (uint8_t)(40 + i);
+
+  MAKEFORMATFILE(format, "data RAW UINT8 8\n");
+
+#ifdef USE_ENC
+  D = gd_open(filedir, GD_RDWR | ENC_ENCODING | GD_VERBOSE);
+#else
+  D = gd_open(filedir, GD_RDWR | ENC_ENCODING);
+#endif
+  n = gd_putdata(D, "data", 5, 0, 1, 0, GD_UINT8, c);
+  e1 = gd_error(D);
+
+  e2 = gd_close(D);
+  CHECKI(e2, 0);
+
+  stat_data = stat(encdata, &buf);
+#ifdef USE_ENC
+  if (stat_data) {
+    perror("stat");
+  }
+  CHECKI(stat_data, 0);
+#else
+  CHECKI(stat_data, -1);
+#endif
+
+#ifdef USE_ENC
+  /* uncompress */
+  ENC_COMPRESS;
+  if (gd_system(command)) {
+    r = 1;
+  } else {
+    fd = open(data, O_RDONLY | O_BINARY);
+    if (fd >= 0) {
+      i = 0;
+      while (read(fd, &d, sizeof(uint8_t))) {
+        if (i < 40 || i > 48) {
+          CHECKIi(i, d, 0);
+        } else
+          CHECKIi(i, d, i);
+        i++;
+      }
+      CHECKI(i, 48);
+      close(fd);
+    }
+  }
+#endif
+
+  unlink_enc = unlink(encdata);
+  CHECKI(unlink_enc, -1);
+
+  unlink_data = unlink(data);
+  unlink(format);
+  rmdir(filedir);
+
+#ifdef USE_ENC
+  CHECKI(unlink_data, 0);
+  CHECKI(e1, GD_E_OK);
+  CHECKI(n, 8);
+#else
+  CHECKI(unlink_data, -1);
+  CHECKI(e1, GD_E_UNSUPPORTED);
+  CHECKI(n, 0);
+#endif
+
+  return r;
+#endif
+}

--- a/test/enc_put_back.c
+++ b/test/enc_put_back.c
@@ -1,0 +1,97 @@
+/* Copyright (C) 2014, 2017 D.V. Wiebe
+ *
+ ***************************************************************************
+ *
+ * This file is part of the GetData project.
+ *
+ * GetData is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the
+ * Free Software Foundation; either version 2.1 of the License, or (at your
+ * option) any later version.
+ *
+ * GetData is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with GetData; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+#include "test.h"
+
+int main(void)
+{
+#if (defined ENC_SKIP_TEST) || ! (defined USE_ENC)
+  return 77;
+#else
+  const char *filedir = "dirfile";
+  const char *format = "dirfile/format";
+  const char *encdata = "dirfile/data" ENC_SUFFIX;
+  const char *data = "dirfile/data";
+  uint8_t c[8];
+  char command[4096];
+  uint8_t d;
+  struct stat buf;
+  int fd, i, n1, n2, e1, e2, e3, stat_data, unlink_data, r = 0;
+  DIRFILE *D;
+
+  rmdirfile();
+  mkdir(filedir, 0700);
+
+  for (i = 0; i < 8; ++i)
+    c[i] = (uint8_t)(40 + i);
+
+  MAKEFORMATFILE(format, "data RAW UINT8 8\n");
+
+  D = gd_open(filedir, GD_RDWR | ENC_ENCODING | GD_VERBOSE);
+  n1 = gd_putdata(D, "data", 5, 0, 1, 0, GD_UINT8, c);
+  e1 = gd_error(D);
+  CHECKI(e1, GD_E_OK);
+  CHECKI(n1, 8);
+
+  n2 = gd_putdata(D, "data", 0, 0, 1, 0, GD_UINT8, c);
+  e2 = gd_error(D);
+  CHECKI(e2, GD_E_OK);
+  CHECKI(n2, 8);
+
+  e3 = gd_close(D);
+  CHECKI(e3, 0);
+
+  stat_data = stat(encdata, &buf);
+  if (stat_data) {
+    perror("stat");
+  }
+  CHECKI(stat_data, 0);
+
+  /* uncompress */
+  ENC_COMPRESS;
+  if (gd_system(command)) {
+    r = 1;
+  } else {
+    fd = open(data, O_RDONLY | O_BINARY);
+    if (fd >= 0) {
+      i = 0;
+      while (read(fd, &d, sizeof(uint8_t))) {
+        if (i < 8) {
+          CHECKIi(i, d, i + 40);
+        } else if (i < 40 || i > 48) {
+          CHECKIi(i, d, 0);
+        } else
+          CHECKIi(i, d, i);
+        i++;
+      }
+      CHECKI(i, 48);
+      close(fd);
+    }
+  }
+
+  unlink_data = unlink(data);
+  unlink(format);
+  rmdir(filedir);
+
+  CHECKI(unlink_data, 0);
+
+  return r;
+#endif
+}

--- a/test/enc_put_endian.c
+++ b/test/enc_put_endian.c
@@ -1,0 +1,114 @@
+/* Copyright (C) 2014, 2017 D.V. Wiebe
+ *
+ ***************************************************************************
+ *
+ * This file is part of the GetData project.
+ *
+ * GetData is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the
+ * Free Software Foundation; either version 2.1 of the License, or (at your
+ * option) any later version.
+ *
+ * GetData is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with GetData; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+#include "test.h"
+
+#ifdef WORDS_BIGENDIAN
+#define ENDIAN "ENDIAN little"
+#else
+#define ENDIAN "ENDIAN big"
+#endif
+
+int main(void)
+{
+#ifdef ENC_SKIP_TEST
+  return 77;
+#else
+  const char *filedir = "dirfile";
+  const char *format = "dirfile/format";
+  const char *encdata = "dirfile/data" ENC_SUFFIX;
+  const char *data = "dirfile/data";
+  uint16_t c[8];
+#ifdef USE_ENC
+  char command[4096];
+  uint16_t d;
+#endif
+  struct stat buf;
+  int fd, i, n, e1, e2, stat_data, unlink_data, r = 0;
+  DIRFILE *D;
+
+  rmdirfile();
+  mkdir(filedir, 0700);
+
+  for (i = 0; i < 8; ++i)
+    c[i] = (uint16_t)(0x102 * i);
+
+  MAKEFORMATFILE(format, "data RAW UINT16 8\n" ENDIAN "\n");
+
+#ifdef USE_ENC
+  D = gd_open(filedir, GD_RDWR | ENC_ENCODING | GD_VERBOSE);
+#else
+  D = gd_open(filedir, GD_RDWR | ENC_ENCODING);
+#endif
+  n = gd_putdata(D, "data", 5, 0, 1, 0, GD_UINT16, c);
+  e1 = gd_error(D);
+
+  e2 = gd_close(D);
+  CHECKI(e2, 0);
+
+  stat_data = stat(encdata, &buf);
+#ifdef USE_ENC
+  if (stat_data) {
+    perror("stat");
+  }
+  CHECKI(stat_data, 0);
+#else
+  CHECKI(stat_data, -1);
+#endif
+
+#ifdef USE_ENC
+  /* uncompress */
+  ENC_COMPRESS;
+  if (gd_system(command)) {
+    r = 1;
+  } else {
+    fd = open(data, O_RDONLY | O_BINARY);
+    if (fd >= 0) {
+      i = 0;
+      while (read(fd, &d, sizeof(uint16_t))) {
+        if (i < 40 || i > 48) {
+          CHECKIi(i, d, 0);
+        } else
+          CHECKIi(i, d, 0x201 * (i - 40));
+        i++;
+      }
+      CHECKI(i, 48);
+      close(fd);
+    }
+  }
+#endif
+
+  unlink_data = unlink(data);
+  unlink(format);
+  rmdir(filedir);
+
+#ifdef USE_ENC
+  CHECKI(unlink_data, 0);
+  CHECKI(e1, GD_E_OK);
+  CHECKI(n, 8);
+#else
+  CHECKI(unlink_data, -1);
+  CHECKI(e1, GD_E_UNSUPPORTED);
+  CHECKI(n, 0);
+#endif
+
+  return r;
+#endif
+}

--- a/test/enc_put_get.c
+++ b/test/enc_put_get.c
@@ -1,0 +1,79 @@
+/* Copyright (C) 2014, 2017 D.V. Wiebe
+ *
+ ***************************************************************************
+ *
+ * This file is part of the GetData project.
+ *
+ * GetData is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the
+ * Free Software Foundation; either version 2.1 of the License, or (at your
+ * option) any later version.
+ *
+ * GetData is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with GetData; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+#include "test.h"
+
+int main(void)
+{
+#ifdef ENC_SKIP_TEST
+  return 77;
+#else
+  const char *filedir = "dirfile";
+  const char *format = "dirfile/format";
+  const char *data = "dirfile/data" ENC_SUFFIX;
+  uint8_t c[8], d[8];
+  int i, m, n, e1, e2, e3, unlink_data, r = 0;
+  DIRFILE *D;
+
+  rmdirfile();
+  mkdir(filedir, 0700);
+
+  for (i = 0; i < 8; ++i)
+    c[i] = (uint8_t)(40 + i);
+
+  MAKEFORMATFILE(format, "data RAW UINT8 8\n");
+
+#ifdef USE_ENC
+  D = gd_open(filedir, GD_RDWR | ENC_ENCODING | GD_VERBOSE);
+#else
+  D = gd_open(filedir, GD_RDWR | ENC_ENCODING);
+#endif
+  n = gd_putdata(D, "data", 5, 0, 1, 0, GD_UINT8, c);
+  e1 = gd_error(D);
+  m = gd_getdata(D, "data", 5, 0, 1, 0, GD_UINT8, d);
+  e2 = gd_error(D);
+
+  for (i = 0; i < m; ++i)
+    CHECKIi(i, d[i], c[i]);
+
+  e3 = gd_close(D);
+  CHECKI(e3, 0);
+
+  unlink_data = unlink(data);
+  unlink(format);
+  rmdir(filedir);
+
+#ifdef USE_ENC
+  CHECKI(unlink_data, 0);
+  CHECKI(e1, GD_E_OK);
+  CHECKI(e2, GD_E_OK);
+  CHECKI(n, 8);
+  CHECKI(m, 8);
+#else
+  CHECKI(unlink_data, -1);
+  CHECKI(e1, GD_E_UNSUPPORTED);
+  CHECKI(e2, GD_E_UNSUPPORTED);
+  CHECKI(n, 0);
+  CHECKI(m, 0);
+#endif
+  
+  return r;
+#endif
+}

--- a/test/enc_put_nframes.c
+++ b/test/enc_put_nframes.c
@@ -1,0 +1,88 @@
+/* Copyright (C) 2015-2026 D. V. Wiebe
+ *
+ ***************************************************************************
+ *
+ * This file is part of the GetData project.
+ *
+ * GetData is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the
+ * Free Software Foundation; either version 2.1 of the License, or (at your
+ * option) any later version.
+ *
+ * GetData is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with GetData; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+#include "test.h"
+
+uint32_t d[100];
+
+int main(void)
+{
+#ifndef USE_ENC
+  return 77;
+#else
+  const char *filedir = "dirfile";
+  const char *format = "dirfile/format";
+  const char *encdata = "dirfile/data" ENC_SUFFIX;
+  int i, e1, e2, r = 0;
+  size_t n1, n2;
+  off_t nf1, nf2, nf3;
+  DIRFILE *D;
+
+  for (i = 0; i < 100; ++i)
+    d[i] = i;
+
+  rmdirfile();
+
+  D = gd_open(filedir,
+      GD_RDWR | ENC_ENCODING | GD_CREAT | GD_EXCL | GD_VERBOSE);
+
+  gd_add_raw(D, "data", GD_UINT32, 1, 0);
+
+  n1 = gd_putdata(D, "data", 0, 0, 0, 100, GD_UINT32, d);
+  CHECKU(n1, 100);
+
+  e1 = gd_error(D);
+  CHECKI(e1, GD_E_OK);
+
+  nf1 = gd_nframes(D);
+  CHECKU(nf1, 100);
+
+  /* The first gd_nframes() may have finalised an out-of-place temporary
+   * file.  A second call must not try to finalise it again (a stale
+   * GD_FILE_WRITE in file[0].mode used to send a NULL temporary name to
+   * gd_RenameAt) */
+  nf2 = gd_nframes(D);
+  CHECKU(nf2, 100);
+
+  e2 = gd_error(D);
+  CHECKI(e2, GD_E_OK);
+
+  gd_close(D);
+
+  D = gd_open(filedir, GD_RDWR | ENC_ENCODING | GD_VERBOSE);
+
+  n2 = gd_putdata(D, "data", 0, 100, 0, 100, GD_UINT32, d);
+  CHECKU(n2, 100);
+
+  e2 = gd_error(D);
+  CHECKI(e2, GD_E_OK);
+
+  nf3 = gd_nframes(D);
+  CHECKU(nf3, 200);
+
+  gd_discard(D);
+
+  unlink(encdata);
+  unlink(format);
+  rmdir(filedir);
+
+  return r;
+#endif
+}

--- a/test/enc_put_pad.c
+++ b/test/enc_put_pad.c
@@ -1,0 +1,99 @@
+/* Copyright (C) 2014, 2017 D.V. Wiebe
+ *
+ ***************************************************************************
+ *
+ * This file is part of the GetData project.
+ *
+ * GetData is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the
+ * Free Software Foundation; either version 2.1 of the License, or (at your
+ * option) any later version.
+ *
+ * GetData is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with GetData; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+#include "test.h"
+
+int main(void)
+{
+#if (defined ENC_SKIP_TEST) || ! (defined USE_ENC)
+  return 77;
+#else
+  const char *filedir = "dirfile";
+  const char *format = "dirfile/format";
+  const char *encdata = "dirfile/data" ENC_SUFFIX;
+  const char *data = "dirfile/data";
+  uint8_t c[8];
+  char command[4096];
+  uint8_t d;
+  struct stat buf;
+  int fd, i, n1, n2, e1, e2, e3, stat_data, unlink_data, r = 0;
+  DIRFILE *D;
+
+  rmdirfile();
+  mkdir(filedir, 0700);
+
+  for (i = 0; i < 8; ++i)
+    c[i] = (uint8_t)(40 + i);
+
+  MAKEFORMATFILE(format, "data RAW UINT8 8\n");
+
+  D = gd_open(filedir, GD_RDWR | ENC_ENCODING | GD_VERBOSE);
+  n1 = gd_putdata(D, "data", 0, 0, 1, 0, GD_UINT8, c);
+  e1 = gd_error(D);
+  CHECKI(e1, GD_E_OK);
+  CHECKI(n1, 8);
+  gd_close(D);
+
+  D = gd_open(filedir, GD_RDWR | ENC_ENCODING | GD_VERBOSE);
+  n2 = gd_putdata(D, "data", 5, 0, 1, 0, GD_UINT8, c);
+  e2 = gd_error(D);
+  CHECKI(e2, GD_E_OK);
+  CHECKI(n2, 8);
+
+  e3 = gd_close(D);
+  CHECKI(e3, 0);
+
+  stat_data = stat(encdata, &buf);
+  if (stat_data) {
+    perror("stat");
+  }
+  CHECKI(stat_data, 0);
+
+  /* uncompress */
+  ENC_COMPRESS;
+  if (gd_system(command)) {
+    r = 1;
+  } else {
+    fd = open(data, O_RDONLY | O_BINARY);
+    if (fd >= 0) {
+      i = 0;
+      while (read(fd, &d, sizeof(uint8_t))) {
+        if (i < 8) {
+          CHECKIi(i, d, i + 40);
+        } else if (i < 40 || i > 48) {
+          CHECKIi(i, d, 0);
+        } else
+          CHECKIi(i, d, i);
+        i++;
+      }
+      CHECKI(i, 48);
+      close(fd);
+    }
+  }
+
+  unlink_data = unlink(data);
+  unlink(format);
+  rmdir(filedir);
+
+  CHECKI(unlink_data, 0);
+
+  return r;
+#endif
+}

--- a/test/enc_put_sub.c
+++ b/test/enc_put_sub.c
@@ -1,0 +1,103 @@
+/* Copyright (C) 2014, 2017 D.V. Wiebe
+ *
+ ***************************************************************************
+ *
+ * This file is part of the GetData project.
+ *
+ * GetData is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the
+ * Free Software Foundation; either version 2.1 of the License, or (at your
+ * option) any later version.
+ *
+ * GetData is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with GetData; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+#include "test.h"
+
+int main(void)
+{
+#if (defined ENC_SKIP_TEST) || ! (defined USE_ENC)
+  return 77;
+#else
+  const char *filedir = "dirfile";
+  const char *subdir = "dirfile/sub";
+  const char *format = "dirfile/format";
+  const char *format1 = "dirfile/sub/format1";
+  const char *encdata = "dirfile/sub/data" ENC_SUFFIX;
+  const char *data = "dirfile/sub/data";
+  uint8_t c[8];
+  char command[4096];
+  uint8_t d;
+  struct stat buf;
+  int fd, i, n1, n2, e1, e2, e3, stat_data, unlink_data, r = 0;
+  DIRFILE *D;
+
+  rmdirfile();
+  mkdir(filedir, 0700);
+  mkdir(subdir, 0700);
+
+  for (i = 0; i < 8; ++i)
+    c[i] = (uint8_t)(40 + i);
+
+  MAKEFORMATFILE(format, "/INCLUDE sub/format1\n");
+  MAKEFORMATFILE(format1, "data RAW UINT8 8\n");
+
+  D = gd_open(filedir, GD_RDWR | ENC_ENCODING | GD_VERBOSE);
+  n1 = gd_putdata(D, "data", 5, 0, 1, 0, GD_UINT8, c);
+  e1 = gd_error(D);
+  CHECKI(e1, GD_E_OK);
+  CHECKI(n1, 8);
+
+  n2 = gd_putdata(D, "data", 0, 0, 1, 0, GD_UINT8, c);
+  e2 = gd_error(D);
+  CHECKI(e2, GD_E_OK);
+  CHECKI(n2, 8);
+
+  e3 = gd_close(D);
+  CHECKI(e3, 0);
+
+  stat_data = stat(encdata, &buf);
+  if (stat_data) {
+    perror("stat");
+  }
+  CHECKI(stat_data, 0);
+
+  /* uncompress */
+  ENC_COMPRESS;
+  if (gd_system(command)) {
+    r = 1;
+  } else {
+    fd = open(data, O_RDONLY | O_BINARY);
+    if (fd >= 0) {
+      i = 0;
+      while (read(fd, &d, sizeof(uint8_t))) {
+        if (i < 8) {
+          CHECKIi(i, d, i + 40);
+        } else if (i < 40 || i > 48) {
+          CHECKIi(i, d, 0);
+        } else
+          CHECKIi(i, d, i);
+        i++;
+      }
+      CHECKI(i, 48);
+      close(fd);
+    }
+  }
+
+  unlink_data = unlink(data);
+  unlink(format1);
+  unlink(format);
+  rmdir(subdir);
+  rmdir(filedir);
+
+  CHECKI(unlink_data, 0);
+
+  return r;
+#endif
+}

--- a/test/enc_sync.c
+++ b/test/enc_sync.c
@@ -1,0 +1,89 @@
+/* Copyright (C) 2014, 2017 D.V. Wiebe
+ *
+ ***************************************************************************
+ *
+ * This file is part of the GetData project.
+ *
+ * GetData is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the
+ * Free Software Foundation; either version 2.1 of the License, or (at your
+ * option) any later version.
+ *
+ * GetData is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with GetData; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+#include "test.h"
+
+int main(void)
+{
+#if !!defined ENC_SKIP_TEST || !defined USE_ENC
+  return 77;
+#else
+  const char *filedir = "dirfile";
+  const char *format = "dirfile/format";
+  const char *encdata = "dirfile/data" ENC_SUFFIX;
+  const char *data = "dirfile/data";
+  uint8_t c[8];
+  char command[4096];
+  uint8_t d;
+  struct stat buf;
+  int fd, i, n, e1, e2, stat_data, r = 0;
+  DIRFILE *D;
+
+  rmdirfile();
+  mkdir(filedir, 0700);
+
+  for (i = 0; i < 8; ++i)
+    c[i] = (uint8_t)(40 + i);
+
+  MAKEFORMATFILE(format, "data RAW UINT8 8\n");
+
+  D = gd_open(filedir, GD_RDWR | ENC_ENCODING | GD_VERBOSE);
+  gd_putdata(D, "data", 5, 0, 1, 0, GD_UINT8, c);
+  n = gd_flush(D, "data");
+  e1 = gd_error(D);
+  CHECKI(e1, GD_E_OK);
+  CHECKI(n, 0);
+
+  e2 = gd_close(D);
+  CHECKI(e2, 0);
+
+  stat_data = stat(encdata, &buf);
+  if (stat_data) {
+    perror("stat");
+  }
+  CHECKI(stat_data, 0);
+
+  /* uncompress */
+  ENC_COMPRESS;
+  if (gd_system(command)) {
+    r = 1;
+  } else {
+    fd = open(data, O_RDONLY | O_BINARY);
+    if (fd >= 0) {
+      i = 0;
+      while (read(fd, &d, sizeof(uint8_t))) {
+        if (i < 40 || i > 48) {
+          CHECKIi(i, d, 0);
+        } else
+          CHECKIi(i, d, i);
+        i++;
+      }
+      CHECKI(i, 48);
+      close(fd);
+    }
+  }
+
+  unlink(data);
+  unlink(format);
+  rmdir(filedir);
+
+  return r;
+#endif
+}

--- a/test/flac_get_get.c
+++ b/test/flac_get_get.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2015, 2017 D. V. Wiebe
+/* Copyright (C) 2026 G. Smecher
  *
  ***************************************************************************
  *
@@ -20,66 +20,19 @@
  */
 #include "test.h"
 
-int main(void)
-{
-#if !defined USE_FLAC || !defined TEST_FLAC
-  return 77; /* skip test */
-#else
-  const char *filedir = "dirfile";
-  const char *format = "dirfile/format";
-  const char *data = "dirfile/data";
-  const char *flacdata = "dirfile/data.flac";
-  uint16_t c1[8], c2[8];
-  char command[4096];
-  int i, n1, e1, e2, n2, e3, r = 0;
-  DIRFILE *D;
-
-  memset(c1, 0, 16);
-  memset(c2, 0, 16);
-  rmdirfile();
-  mkdir(filedir, 0700);
-
-  MAKEFORMATFILE(format, "data RAW UINT16 8\n");
-  MAKEDATAFILE(data, uint16_t, i, 256);
-
-#ifdef WORDS_BIGENDIAN
-#define ENDIANNESS "--endian=big"
-#else
-#define ENDIANNESS "--endian=little"
+#ifndef TEST_FLAC
+#define ENC_SKIP_TEST 1
 #endif
 
-  snprintf(command, 4096,
-      "\"%s\" " ENDIANNESS " --silent --sample-rate=1 --channels=1 --bps=16 "
-      "--sign=signed --delete-input-file %s >%s 2>%s", FLAC,
-      data, NULL_DEVICE, NULL_DEVICE);
-  if (gd_system(command))
-    return 1;
-
-  D = gd_open(filedir, GD_RDONLY | GD_VERBOSE);
-  n1 = gd_getdata(D, "data", 5, 0, 1, 0, GD_UINT16, c1);
-  CHECKI(n1, 8);
-  e1 = gd_error(D);
-  CHECKI(e1, 0);
-
-  e2 = gd_close(D);
-  CHECKI(e2, 0);
-
-  D = gd_open(filedir, GD_RDONLY | GD_VERBOSE);
-  n2 = gd_getdata(D, "data", 5, 0, 1, 0, GD_UINT16, c2);
-  e3 = gd_error(D);
-  CHECKI(e3, 0);
-  CHECKI(n2, 8);
-  for (i = 0; i < 8; ++i) {
-    CHECKIi(i,c1[i], 40 + i);
-    CHECKIi(i,c2[i], 40 + i);
-  }
-
-  gd_discard(D);
-
-  unlink(flacdata);
-  unlink(format);
-  rmdir(filedir);
-
-  return r;
+#ifdef USE_FLAC
+#define USE_ENC 1
 #endif
-}
+
+#define ENC_SUFFIX ".flac"
+#define ENC_COMPRESS \
+  snprintf(command, 4096, \
+  "\"%s\" " ENDIANNESS " --silent --sample-rate=1 --channels=1 --bps=16 " \
+  "--sign=signed --delete-input-file %s >%s 2>%s", FLAC, \
+  data, NULL_DEVICE, NULL_DEVICE)
+
+#include "enc_get_get.c"

--- a/test/flac_get_get2.c
+++ b/test/flac_get_get2.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2015, 2017 D. V. Wiebe
+/* Copyright (C) 2026 G. Smecher
  *
  ***************************************************************************
  *
@@ -20,62 +20,19 @@
  */
 #include "test.h"
 
-int main(void)
-{
-#if !defined USE_FLAC || !defined TEST_FLAC
-  return 77; /* skip test */
-#else
-  const char *filedir = "dirfile";
-  const char *format = "dirfile/format";
-  const char *data = "dirfile/data";
-  const char *flacdata = "dirfile/data.flac";
-  uint16_t c1[8], c2[8];
-  char command[4096];
-  int i, n1, error1, n2, error2, r = 0;
-  DIRFILE *D;
-
-  memset(c1, 0, 16);
-  memset(c2, 0, 16);
-  rmdirfile();
-  mkdir(filedir, 0700);
-
-  MAKEFORMATFILE(format, "data RAW UINT16 8\n");
-  MAKEDATAFILE(data, uint16_t, i, 256);
-
-#ifdef WORDS_BIGENDIAN
-#define ENDIANNESS "--endian=big"
-#else
-#define ENDIANNESS "--endian=little"
+#ifndef TEST_FLAC
+#define ENC_SKIP_TEST 1
 #endif
 
-  /* compress */
-  snprintf(command, 4096,
-      "\"%s\" " ENDIANNESS " --silent --sample-rate=1 --channels=1 --bps=16 "
-      "--sign=signed --delete-input-file %s >%s 2>%s", FLAC,
-      data, NULL_DEVICE, NULL_DEVICE);
-  if (gd_system(command))
-    return 1;
-
-  D = gd_open(filedir, GD_RDONLY | GD_VERBOSE);
-  n1 = gd_getdata(D, "data", 0, 0, 1, 0, GD_UINT16, c1);
-  error1 = gd_error(D);
-  n2 = gd_getdata(D, "data", 0, 0, 1, 0, GD_UINT16, c2);
-  error2 = gd_error(D);
-  gd_discard(D);
-
-  unlink(flacdata);
-  unlink(format);
-  rmdir(filedir);
-
-  CHECKI(error1, 0);
-  CHECKI(error2, 0);
-  CHECKI(n1, 8);
-  CHECKI(n2, 8);
-  for (i = 0; i < 8; ++i) {
-    CHECKUi(i,c1[i], i);
-    CHECKUi(i,c2[i], i);
-  }
-
-  return r;
+#ifdef USE_FLAC
+#define USE_ENC 1
 #endif
-}
+
+#define ENC_SUFFIX ".flac"
+#define ENC_COMPRESS \
+  snprintf(command, 4096, \
+  "\"%s\" " ENDIANNESS " --silent --sample-rate=1 --channels=1 --bps=16 " \
+  "--sign=signed --delete-input-file %s >%s 2>%s", FLAC, \
+  data, NULL_DEVICE, NULL_DEVICE)
+
+#include "enc_get_get2.c"

--- a/test/flac_put_nframes.c
+++ b/test/flac_put_nframes.c
@@ -20,15 +20,11 @@
  */
 #include "test.h"
 
-#ifndef TEST_LZMA
-#define ENC_SKIP_TEST 1
-#endif
-
-#ifdef USE_LZMA
+#ifdef USE_FLAC
 #define USE_ENC 1
 #endif
 
-#define ENC_SUFFIX ".xz"
-#define ENC_ENCODING GD_LZMA_ENCODED
+#define ENC_SUFFIX ".flac"
+#define ENC_ENCODING GD_FLAC_ENCODED
 
-#include "enc_put_get.c"
+#include "enc_put_nframes.c"

--- a/test/gzip_get_far.c
+++ b/test/gzip_get_far.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2014, 2017 D.V. Wiebe
+/* Copyright (C) 2026 G. Smecher
  *
  ***************************************************************************
  *
@@ -20,53 +20,16 @@
  */
 #include "test.h"
 
-int main(void)
-{
 #ifndef TEST_GZIP
-  return 77;
-#else
-  const char *filedir = "dirfile";
-  const char *format = "dirfile/format";
-  const char *data = "dirfile/data";
-  const char *gzipdata = "dirfile/data.gz";
-  uint16_t c[8];
-  char command[4096];
-  int n, error, r = 0;
-  DIRFILE *D;
-
-  memset(c, 0, 8 * sizeof(*c));
-  rmdirfile();
-  mkdir(filedir, 0700);
-
-  MAKEFORMATFILE(format, "data RAW UINT16 8\n");
-  MAKEDATAFILE(data, uint16_t, i, 256);
-
-  /* compress */
-  snprintf(command, 4096, "\"%s\" -f %s > %s", GZIP, data, NULL_DEVICE);
-  if (gd_system(command))
-    return 1;
+#define ENC_SKIP_TEST 1
+#endif
 
 #ifdef USE_GZIP
-  D = gd_open(filedir, GD_RDONLY | GD_VERBOSE);
-#else
-  D = gd_open(filedir, GD_RDONLY);
+#define USE_ENC 1
 #endif
-  n = gd_getdata(D, "data", 1000, 0, 1, 0, GD_UINT16, c);
-  error = gd_error(D);
 
-  gd_discard(D);
+#define ENC_SUFFIX ".gz"
+#define ENC_COMPRESS \
+  snprintf(command, 4096, "\"%s\" -f %s > %s", GZIP, data, NULL_DEVICE)
 
-  unlink(gzipdata);
-  unlink(format);
-  rmdir(filedir);
-
-#ifdef USE_GZIP
-  CHECKI(error, 0);
-#else
-  CHECKI(error, GD_E_UNSUPPORTED);
-#endif
-  CHECKI(n, 0);
-
-  return r;
-#endif
-}
+#include "enc_get_far.c"

--- a/test/gzip_get_get2.c
+++ b/test/gzip_get_get2.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2008-2011, 2013, 2017 D.V. Wiebe
+/* Copyright (C) 2026 G. Smecher
  *
  ***************************************************************************
  *
@@ -18,56 +18,18 @@
  * along with GetData; if not, write to the Free Software Foundation, Inc.,
  * 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
  */
-/* Attempt to read UINT8 */
 #include "test.h"
 
-int main(void)
-{
-#if !defined USE_GZIP || !defined TEST_GZIP
-  return 77; /* skip test */
-#else
-  const char *filedir = "dirfile";
-  const char *format = "dirfile/format";
-  const char *data = "dirfile/data";
-  const char *gzipdata = "dirfile/data.gz";
-  uint16_t c1[8], c2[8];
-  char command[4096];
-  int i, n1, error1, n2, error2, r = 0;
-  DIRFILE *D;
-
-  memset(c1, 0, 16);
-  memset(c2, 0, 16);
-  rmdirfile();
-  mkdir(filedir, 0700);
-
-  MAKEFORMATFILE(format, "data RAW UINT16 8\n");
-  MAKEDATAFILE(data, uint16_t, i, 256);
-
-  /* compress */
-  snprintf(command, 4096, "\"%s\" -f %s > %s", GZIP, data, NULL_DEVICE);
-  if (gd_system(command))
-    return 1;
-
-  D = gd_open(filedir, GD_RDONLY | GD_VERBOSE);
-  n1 = gd_getdata(D, "data", 0, 0, 1, 0, GD_UINT16, c1);
-  error1 = gd_error(D);
-  n2 = gd_getdata(D, "data", 0, 0, 1, 0, GD_UINT16, c2);
-  error2 = gd_error(D);
-  gd_discard(D);
-
-  unlink(gzipdata);
-  unlink(format);
-  rmdir(filedir);
-
-  CHECKI(error1, 0);
-  CHECKI(error2, 0);
-  CHECKI(n1, 8);
-  CHECKI(n2, 8);
-  for (i = 0; i < 8; ++i) {
-    CHECKUi(i,c1[i], i);
-    CHECKUi(i,c2[i], i);
-  }
-
-  return r;
+#ifndef TEST_GZIP
+#define ENC_SKIP_TEST 1
 #endif
-}
+
+#ifdef USE_GZIP
+#define USE_ENC 1
+#endif
+
+#define ENC_SUFFIX ".gz"
+#define ENC_COMPRESS \
+  snprintf(command, 4096, "\"%s\" -f %s > %s", GZIP, data, NULL_DEVICE)
+
+#include "enc_get_get2.c"

--- a/test/gzip_move_to.c
+++ b/test/gzip_move_to.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2011, 2013, 2017 D.V. Wiebe
+/* Copyright (C) 2026 G. Smecher
  *
  ***************************************************************************
  *
@@ -20,89 +20,17 @@
  */
 #include "test.h"
 
-int main(void)
-{
-  const char *filedir = "dirfile";
-  const char *format = "dirfile/format";
-  const char *data_gz = "dirfile/data.gz";
-  const char *data_raw = "dirfile/data";
-  uint8_t data_in[256];
-  DIRFILE *D;
-#ifdef USE_GZIP
-  uint8_t d;
-  char command[4096];
-  int i;
-#endif
-  int fd, e1, e2, unlink_raw, r = 0;
-  struct stat buf;
-
-  rmdirfile();
-  mkdir(filedir, 0700); 
-
-  for (fd = 0; fd < 256; ++fd)
-    data_in[fd] = (unsigned char)fd;
-
-  MAKEFORMATFILE(format, "data RAW UINT8 8\n/ENCODING none\n/ENDIAN little\n");
-
-  fd = open(data_raw, O_CREAT | O_EXCL | O_WRONLY | O_BINARY, 0666);
-  write(fd, data_in, 256);
-  close(fd);
-
-#ifdef USE_GZIP
-  D = gd_open(filedir, GD_RDWR | GD_VERBOSE);
-#else
-  D = gd_open(filedir, GD_RDWR);
-#endif
-  gd_alter_encoding(D, GD_GZIP_ENCODED, 0, 1);
-  e1 = gd_error(D);
-
-  e2 = gd_close(D);
-  CHECKI(e2, 0);
-
-#ifdef USE_GZIP
-  if (stat(data_gz, &buf)) {
-    perror("stat");
-    r = 1;
-  }
-  CHECKI(stat(data_raw, &buf), -1);
-#else
-  if (stat(data_raw, &buf)) {
-    perror("stat");
-    r = 1;
-  }
-  CHECKI(stat(data_gz, &buf), -1);
+#ifndef TEST_GZIP
+#define ENC_SKIP_TEST 1
 #endif
 
 #ifdef USE_GZIP
-  /* uncompress */
-  snprintf(command, 4096, "\"%s\" -df %s > %s", GZIP, data_gz, NULL_DEVICE);
-  if (gd_system(command)) {
-    fprintf(stderr, "command failed: %s\n", command);
-    r = 1;
-  } else {
-    fd = open(data_raw, O_RDONLY | O_BINARY);
-    if (fd >= 0) {
-      i = 0;
-      while (read(fd, &d, sizeof(uint8_t))) {
-        CHECKIi(i, d, i);
-        i++;
-      }
-      CHECKI(i, 256);
-      close(fd);
-    }
-  }
+#define USE_ENC 1
 #endif
 
-  unlink_raw = unlink(data_raw);
-  unlink(format);
-  rmdir(filedir);
+#define ENC_SUFFIX ".gz"
+#define ENC_ENCODING GD_GZIP_ENCODED
+#define ENC_COMPRESS \
+  snprintf(command, 4096, "\"%s\" -df %s > %s", GZIP, encdata, NULL_DEVICE)
 
-  CHECKI(unlink_raw, 0);
-#ifdef USE_GZIP
-  CHECKI(e1, GD_E_OK);
-#else
-  CHECKI(e1, GD_E_UNSUPPORTED);
-#endif
-
-  return r;
-}
+#include "enc_move_to.c"

--- a/test/gzip_put_back.c
+++ b/test/gzip_put_back.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2013, 2017 D.V. Wiebe
+/* Copyright (C) 2026 G. Smecher
  *
  ***************************************************************************
  *
@@ -20,78 +20,17 @@
  */
 #include "test.h"
 
-int main(void)
-{
-#if ! (defined TEST_GZIP) || ! (defined USE_GZIP)
-  return 77;
-#else
-  const char *filedir = "dirfile";
-  const char *format = "dirfile/format";
-  const char *data_gz = "dirfile/data.gz";
-  const char *data = "dirfile/data";
-  uint8_t c[8];
-  char command[4096];
-  uint8_t d;
-  struct stat buf;
-  int fd, i, n1, n2, e1, e2, e3, stat_data, unlink_data, r = 0;
-  DIRFILE *D;
-
-  rmdirfile();
-  mkdir(filedir, 0700);
-
-  for (i = 0; i < 8; ++i)
-    c[i] = (uint8_t)(40 + i);
-
-  MAKEFORMATFILE(format, "data RAW UINT8 8\n");
-
-  D = gd_open(filedir, GD_RDWR | GD_GZIP_ENCODED | GD_VERBOSE);
-  n1 = gd_putdata(D, "data", 5, 0, 1, 0, GD_UINT8, c);
-  e1 = gd_error(D);
-  CHECKI(e1, GD_E_OK);
-  CHECKI(n1, 8);
-
-  n2 = gd_putdata(D, "data", 0, 0, 1, 0, GD_UINT8, c);
-  e2 = gd_error(D);
-  CHECKI(e2, GD_E_OK);
-  CHECKI(n2, 8);
-
-  e3 = gd_close(D);
-  CHECKI(e3, 0);
-
-  stat_data = stat(data_gz, &buf);
-  if (stat_data) {
-    perror("stat");
-  }
-  CHECKI(stat_data, 0);
-
-  /* uncompress */
-  snprintf(command, 4096, "\"%s\" -df %s > %s", GZIP, data, NULL_DEVICE);
-  if (gd_system(command)) {
-    r = 1;
-  } else {
-    fd = open(data, O_RDONLY | O_BINARY);
-    if (fd >= 0) {
-      i = 0;
-      while (read(fd, &d, sizeof(uint8_t))) {
-        if (i < 8) {
-          CHECKIi(i, d, i + 40);
-        } else if (i < 40 || i > 48) {
-          CHECKIi(i, d, 0);
-        } else
-          CHECKIi(i, d, i);
-        i++;
-      }
-      CHECKI(i, 48);
-      close(fd);
-    }
-  }
-
-  unlink_data = unlink(data);
-  unlink(format);
-  rmdir(filedir);
-
-  CHECKI(unlink_data, 0);
-
-  return r;
+#ifndef TEST_GZIP
+#define ENC_SKIP_TEST 1
 #endif
-}
+
+#ifdef USE_GZIP
+#define USE_ENC 1
+#endif
+
+#define ENC_SUFFIX ".gz"
+#define ENC_ENCODING GD_GZIP_ENCODED
+#define ENC_COMPRESS \
+  snprintf(command, 4096, "\"%s\" -df %s > %s", GZIP, data, NULL_DEVICE)
+
+#include "enc_put_back.c"

--- a/test/gzip_put_endian.c
+++ b/test/gzip_put_endian.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2013, 2017 D.V. Wiebe
+/* Copyright (C) 2026 G. Smecher
  *
  ***************************************************************************
  *
@@ -20,95 +20,17 @@
  */
 #include "test.h"
 
-#ifdef WORDS_BIGENDIAN
-#define ENDIAN "ENDIAN little"
-#else
-#define ENDIAN "ENDIAN big"
-#endif
-
-int main(void)
-{
 #ifndef TEST_GZIP
-  return 77;
-#else
-  const char *filedir = "dirfile";
-  const char *format = "dirfile/format";
-  const char *data_gz = "dirfile/data.gz";
-  const char *data = "dirfile/data";
-  uint16_t c[8];
-#ifdef USE_GZIP
-  char command[4096];
-  uint16_t d;
-#endif
-  struct stat buf;
-  int fd, i, n, e1, e2, stat_data, unlink_data, r = 0;
-  DIRFILE *D;
-
-  rmdirfile();
-  mkdir(filedir, 0700);
-
-  for (i = 0; i < 8; ++i)
-    c[i] = (uint16_t)(0x102 * i);
-
-  MAKEFORMATFILE(format, "data RAW UINT16 8\n" ENDIAN "\n");
-
-#ifdef USE_GZIP
-  D = gd_open(filedir, GD_RDWR | GD_GZIP_ENCODED | GD_VERBOSE);
-#else
-  D = gd_open(filedir, GD_RDWR | GD_GZIP_ENCODED);
-#endif
-  n = gd_putdata(D, "data", 5, 0, 1, 0, GD_UINT16, c);
-  e1 = gd_error(D);
-
-  e2 = gd_close(D);
-  CHECKI(e2, 0);
-
-  stat_data = stat(data_gz, &buf);
-#ifdef USE_GZIP
-  if (stat_data) {
-    perror("stat");
-  }
-  CHECKI(stat_data, 0);
-#else
-  CHECKI(stat_data, -1);
+#define ENC_SKIP_TEST 1
 #endif
 
 #ifdef USE_GZIP
-  /* uncompress */
-  snprintf(command, 4096, "\"%s\" -df %s > %s", GZIP, data, NULL_DEVICE);
-  if (gd_system(command)) {
-    r = 1;
-  } else {
-    fd = open(data, O_RDONLY | O_BINARY);
-    if (fd >= 0) {
-      i = 0;
-      while (read(fd, &d, sizeof(uint16_t))) {
-        if (i < 40 || i > 48) {
-          CHECKIi(i, d, 0);
-        } else
-          CHECKIi(i, d, 0x201 * (i - 40));
-        i++;
-      }
-      CHECKI(i, 48);
-      close(fd);
-    }
-  }
+#define USE_ENC 1
 #endif
 
-  unlink_data = unlink(data);
-  unlink(format);
-  rmdir(filedir);
+#define ENC_SUFFIX ".gz"
+#define ENC_ENCODING GD_GZIP_ENCODED
+#define ENC_COMPRESS \
+  snprintf(command, 4096, "\"%s\" -df %s > %s", GZIP, data, NULL_DEVICE)
 
-#ifdef USE_GZIP
-  CHECKI(unlink_data, 0);
-  CHECKI(e1, GD_E_OK);
-  CHECKI(n, 8);
-#else
-  CHECKI(unlink_data, -1);
-  CHECKI(e1, GD_E_UNSUPPORTED);
-  CHECKI(n, 0);
-#endif
-
-  return r;
-#endif
-}
+#include "enc_put_endian.c"

--- a/test/gzip_put_get.c
+++ b/test/gzip_put_get.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2008-2011, 2013, 2017 D.V. Wiebe
+/* Copyright (C) 2026 G. Smecher
  *
  ***************************************************************************
  *
@@ -20,60 +20,15 @@
  */
 #include "test.h"
 
-int main(void)
-{
 #ifndef TEST_GZIP
-  return 77;
-#else
-  const char *filedir = "dirfile";
-  const char *format = "dirfile/format";
-  const char *data = "dirfile/data.gz";
-  uint8_t c[8], d[8];
-  int i, m, n, e1, e2, e3, unlink_data, r = 0;
-  DIRFILE *D;
-
-  rmdirfile();
-  mkdir(filedir, 0700);
-
-  for (i = 0; i < 8; ++i)
-    c[i] = (uint8_t)(40 + i);
-
-  MAKEFORMATFILE(format, "data RAW UINT8 8\n");
+#define ENC_SKIP_TEST 1
+#endif
 
 #ifdef USE_GZIP
-  D = gd_open(filedir, GD_RDWR | GD_GZIP_ENCODED | GD_VERBOSE);
-#else
-  D = gd_open(filedir, GD_RDWR | GD_GZIP_ENCODED);
+#define USE_ENC 1
 #endif
-  n = gd_putdata(D, "data", 5, 0, 1, 0, GD_UINT8, c);
-  e1 = gd_error(D);
-  m = gd_getdata(D, "data", 5, 0, 1, 0, GD_UINT8, d);
-  e2 = gd_error(D);
 
-  for (i = 0; i < m; ++i)
-    CHECKIi(i, d[i], c[i]);
+#define ENC_SUFFIX ".gz"
+#define ENC_ENCODING GD_GZIP_ENCODED
 
-  e3 = gd_close(D);
-  CHECKI(e3, 0);
-
-  unlink_data = unlink(data);
-  unlink(format);
-  rmdir(filedir);
-
-#ifdef USE_GZIP
-  CHECKI(unlink_data, 0);
-  CHECKI(e1, GD_E_OK);
-  CHECKI(e2, GD_E_OK);
-  CHECKI(n, 8);
-  CHECKI(m, 8);
-#else
-  CHECKI(unlink_data, -1);
-  CHECKI(e1, GD_E_UNSUPPORTED);
-  CHECKI(e2, GD_E_UNSUPPORTED);
-  CHECKI(n, 0);
-  CHECKI(m, 0);
-#endif
-  
-  return r;
-#endif
-}
+#include "enc_put_get.c"

--- a/test/gzip_put_nframes.c
+++ b/test/gzip_put_nframes.c
@@ -20,59 +20,11 @@
  */
 #include "test.h"
 
-uint32_t d[100];
-
-int main(void)
-{
-#ifndef USE_GZIP
-  return 77;
-#else
-  const char *filedir = "dirfile";
-  const char *format = "dirfile/format";
-  const char *data = "dirfile/data.gz";
-  int i, e1, e2, r = 0;
-  size_t n1, n2;
-  off_t nf1, nf2;
-  DIRFILE *D;
-
-  for (i = 0; i < 100; ++i)
-    d[i] = i;
-
-  rmdirfile();
-
-  D = gd_open(filedir,
-      GD_RDWR | GD_GZIP_ENCODED | GD_CREAT | GD_EXCL | GD_VERBOSE);
-
-  gd_add_raw(D, "data", GD_UINT32, 1, 0);
-
-  n1 = gd_putdata(D, "data", 0, 0, 0, 100, GD_UINT32, d);
-  CHECKU(n1, 100);
-
-  e1 = gd_error(D);
-  CHECKI(e1, GD_E_OK);
-
-  nf1 = gd_nframes(D);
-  CHECKU(nf1, 100);
-
-  gd_close(D);
-
-  D = gd_open(filedir, GD_RDWR | GD_GZIP_ENCODED | GD_VERBOSE);
-
-  n2 = gd_putdata(D, "data", 0, 100, 0, 100, GD_UINT32, d);
-  CHECKU(n2, 100);
-
-  e2 = gd_error(D);
-  CHECKI(e2, GD_E_OK);
-
-  nf2 = gd_nframes(D);
-  CHECKU(nf2, 200);
-
-  gd_discard(D);
-
-  unlink(data);
-  unlink(format);
-  rmdir(filedir);
-
-  return r;
+#ifdef USE_GZIP
+#define USE_ENC 1
 #endif
-}
+
+#define ENC_SUFFIX ".gz"
+#define ENC_ENCODING GD_GZIP_ENCODED
+
+#include "enc_put_nframes.c"

--- a/test/gzip_put_pad.c
+++ b/test/gzip_put_pad.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2014, 2017 D.V. Wiebe
+/* Copyright (C) 2026 G. Smecher
  *
  ***************************************************************************
  *
@@ -20,80 +20,17 @@
  */
 #include "test.h"
 
-int main(void)
-{
-#if ! (defined TEST_GZIP) || ! (defined USE_GZIP)
-  return 77;
-#else
-  const char *filedir = "dirfile";
-  const char *format = "dirfile/format";
-  const char *data_gz = "dirfile/data.gz";
-  const char *data = "dirfile/data";
-  uint8_t c[8];
-  char command[4096];
-  uint8_t d;
-  struct stat buf;
-  int fd, i, n1, n2, e1, e2, e3, stat_data, unlink_data, r = 0;
-  DIRFILE *D;
-
-  rmdirfile();
-  mkdir(filedir, 0700);
-
-  for (i = 0; i < 8; ++i)
-    c[i] = (uint8_t)(40 + i);
-
-  MAKEFORMATFILE(format, "data RAW UINT8 8\n");
-
-  D = gd_open(filedir, GD_RDWR | GD_GZIP_ENCODED | GD_VERBOSE);
-  n1 = gd_putdata(D, "data", 0, 0, 1, 0, GD_UINT8, c);
-  e1 = gd_error(D);
-  CHECKI(e1, GD_E_OK);
-  CHECKI(n1, 8);
-  gd_close(D);
-
-  D = gd_open(filedir, GD_RDWR | GD_GZIP_ENCODED | GD_VERBOSE);
-  n2 = gd_putdata(D, "data", 5, 0, 1, 0, GD_UINT8, c);
-  e2 = gd_error(D);
-  CHECKI(e2, GD_E_OK);
-  CHECKI(n2, 8);
-
-  e3 = gd_close(D);
-  CHECKI(e3, 0);
-
-  stat_data = stat(data_gz, &buf);
-  if (stat_data) {
-    perror("stat");
-  }
-  CHECKI(stat_data, 0);
-
-  /* uncompress */
-  snprintf(command, 4096, "\"%s\" -df %s > %s", GZIP, data, NULL_DEVICE);
-  if (gd_system(command)) {
-    r = 1;
-  } else {
-    fd = open(data, O_RDONLY | O_BINARY);
-    if (fd >= 0) {
-      i = 0;
-      while (read(fd, &d, sizeof(uint8_t))) {
-        if (i < 8) {
-          CHECKIi(i, d, i + 40);
-        } else if (i < 40 || i > 48) {
-          CHECKIi(i, d, 0);
-        } else
-          CHECKIi(i, d, i);
-        i++;
-      }
-      CHECKI(i, 48);
-      close(fd);
-    }
-  }
-
-  unlink_data = unlink(data);
-  unlink(format);
-  rmdir(filedir);
-
-  CHECKI(unlink_data, 0);
-
-  return r;
+#ifndef TEST_GZIP
+#define ENC_SKIP_TEST 1
 #endif
-}
+
+#ifdef USE_GZIP
+#define USE_ENC 1
+#endif
+
+#define ENC_SUFFIX ".gz"
+#define ENC_ENCODING GD_GZIP_ENCODED
+#define ENC_COMPRESS \
+  snprintf(command, 4096, "\"%s\" -df %s > %s", GZIP, data, NULL_DEVICE)
+
+#include "enc_put_pad.c"

--- a/test/gzip_put_sub.c
+++ b/test/gzip_put_sub.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2013, 2017 D.V. Wiebe
+/* Copyright (C) 2026 G. Smecher
  *
  ***************************************************************************
  *
@@ -20,84 +20,17 @@
  */
 #include "test.h"
 
-int main(void)
-{
-#if ! (defined TEST_GZIP) || ! (defined USE_GZIP)
-  return 77;
-#else
-  const char *filedir = "dirfile";
-  const char *subdir = "dirfile/sub";
-  const char *format = "dirfile/format";
-  const char *format1 = "dirfile/sub/format1";
-  const char *data_gz = "dirfile/sub/data.gz";
-  const char *data = "dirfile/sub/data";
-  uint8_t c[8];
-  char command[4096];
-  uint8_t d;
-  struct stat buf;
-  int fd, i, n1, n2, e1, e2, e3, stat_data, unlink_data, r = 0;
-  DIRFILE *D;
-
-  rmdirfile();
-  mkdir(filedir, 0700);
-  mkdir(subdir, 0700);
-
-  for (i = 0; i < 8; ++i)
-    c[i] = (uint8_t)(40 + i);
-
-  MAKEFORMATFILE(format, "/INCLUDE sub/format1\n");
-  MAKEFORMATFILE(format1, "data RAW UINT8 8\n");
-
-  D = gd_open(filedir, GD_RDWR | GD_GZIP_ENCODED | GD_VERBOSE);
-  n1 = gd_putdata(D, "data", 5, 0, 1, 0, GD_UINT8, c);
-  e1 = gd_error(D);
-  CHECKI(e1, GD_E_OK);
-  CHECKI(n1, 8);
-
-  n2 = gd_putdata(D, "data", 0, 0, 1, 0, GD_UINT8, c);
-  e2 = gd_error(D);
-  CHECKI(e2, GD_E_OK);
-  CHECKI(n2, 8);
-
-  e3 = gd_close(D);
-  CHECKI(e3, 0);
-
-  stat_data = stat(data_gz, &buf);
-  if (stat_data) {
-    perror("stat");
-  }
-  CHECKI(stat_data, 0);
-
-  /* uncompress */
-  snprintf(command, 4096, "\"%s\" -df %s > %s", GZIP, data, NULL_DEVICE);
-  if (gd_system(command)) {
-    r = 1;
-  } else {
-    fd = open(data, O_RDONLY | O_BINARY);
-    if (fd >= 0) {
-      i = 0;
-      while (read(fd, &d, sizeof(uint8_t))) {
-        if (i < 8) {
-          CHECKIi(i, d, i + 40);
-        } else if (i < 40 || i > 48) {
-          CHECKIi(i, d, 0);
-        } else
-          CHECKIi(i, d, i);
-        i++;
-      }
-      CHECKI(i, 48);
-      close(fd);
-    }
-  }
-
-  unlink_data = unlink(data);
-  unlink(format1);
-  unlink(format);
-  rmdir(subdir);
-  rmdir(filedir);
-
-  CHECKI(unlink_data, 0);
-
-  return r;
+#ifndef TEST_GZIP
+#define ENC_SKIP_TEST 1
 #endif
-}
+
+#ifdef USE_GZIP
+#define USE_ENC 1
+#endif
+
+#define ENC_SUFFIX ".gz"
+#define ENC_ENCODING GD_GZIP_ENCODED
+#define ENC_COMPRESS \
+  snprintf(command, 4096, "\"%s\" -df %s > %s", GZIP, data, NULL_DEVICE)
+
+#include "enc_put_sub.c"

--- a/test/gzip_sync.c
+++ b/test/gzip_sync.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2013, 2017 D.V. Wiebe
+/* Copyright (C) 2026 G. Smecher
  *
  ***************************************************************************
  *
@@ -20,70 +20,17 @@
  */
 #include "test.h"
 
-int main(void)
-{
-#if !defined TEST_GZIP || !defined USE_GZIP
-  return 77;
-#else
-  const char *filedir = "dirfile";
-  const char *format = "dirfile/format";
-  const char *data_gz = "dirfile/data.gz";
-  const char *data = "dirfile/data";
-  uint8_t c[8];
-  char command[4096];
-  uint8_t d;
-  struct stat buf;
-  int fd, i, n, e1, e2, stat_data, r = 0;
-  DIRFILE *D;
-
-  rmdirfile();
-  mkdir(filedir, 0700);
-
-  for (i = 0; i < 8; ++i)
-    c[i] = (uint8_t)(40 + i);
-
-  MAKEFORMATFILE(format, "data RAW UINT8 8\n");
-
-  D = gd_open(filedir, GD_RDWR | GD_GZIP_ENCODED | GD_VERBOSE);
-  gd_putdata(D, "data", 5, 0, 1, 0, GD_UINT8, c);
-  n = gd_flush(D, "data");
-  e1 = gd_error(D);
-  CHECKI(e1, GD_E_OK);
-  CHECKI(n, 0);
-
-  e2 = gd_close(D);
-  CHECKI(e2, 0);
-
-  stat_data = stat(data_gz, &buf);
-  if (stat_data) {
-    perror("stat");
-  }
-  CHECKI(stat_data, 0);
-
-  /* uncompress */
-  snprintf(command, 4096, "\"%s\" -df %s > %s", GZIP, data, NULL_DEVICE);
-  if (gd_system(command)) {
-    r = 1;
-  } else {
-    fd = open(data, O_RDONLY | O_BINARY);
-    if (fd >= 0) {
-      i = 0;
-      while (read(fd, &d, sizeof(uint8_t))) {
-        if (i < 40 || i > 48) {
-          CHECKIi(i, d, 0);
-        } else
-          CHECKIi(i, d, i);
-        i++;
-      }
-      CHECKI(i, 48);
-      close(fd);
-    }
-  }
-
-  unlink(data);
-  unlink(format);
-  rmdir(filedir);
-
-  return r;
+#ifndef TEST_GZIP
+#define ENC_SKIP_TEST 1
 #endif
-}
+
+#ifdef USE_GZIP
+#define USE_ENC 1
+#endif
+
+#define ENC_SUFFIX ".gz"
+#define ENC_ENCODING GD_GZIP_ENCODED
+#define ENC_COMPRESS \
+  snprintf(command, 4096, "\"%s\" -df %s > %s", GZIP, data, NULL_DEVICE)
+
+#include "enc_sync.c"

--- a/test/lzma_xz_get_far.c
+++ b/test/lzma_xz_get_far.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2014, 2017 D.V. Wiebe
+/* Copyright (C) 2026 G. Smecher
  *
  ***************************************************************************
  *
@@ -20,53 +20,16 @@
  */
 #include "test.h"
 
-int main(void)
-{
 #ifndef TEST_LZMA
-  return 77;
-#else
-  const char *filedir = "dirfile";
-  const char *format = "dirfile/format";
-  const char *data = "dirfile/data";
-  const char *xzdata = "dirfile/data.xz";
-  uint16_t c[8];
-  char command[4096];
-  int n, error, r = 0;
-  DIRFILE *D;
-
-  memset(c, 0, 8 * sizeof(*c));
-  rmdirfile();
-  mkdir(filedir, 0700);
-
-  MAKEFORMATFILE(format, "data RAW UINT16 8\n");
-  MAKEDATAFILE(data, uint16_t, i, 256);
-
-  /* compress */
-  snprintf(command, 4096, "\"%s\" -f %s > %s", XZ, data, NULL_DEVICE);
-  if (gd_system(command))
-    return 1;
+#define ENC_SKIP_TEST 1
+#endif
 
 #ifdef USE_LZMA
-  D = gd_open(filedir, GD_RDONLY | GD_VERBOSE);
-#else
-  D = gd_open(filedir, GD_RDONLY);
+#define USE_ENC 1
 #endif
-  n = gd_getdata(D, "data", 1000, 0, 1, 0, GD_UINT16, c);
-  error = gd_error(D);
 
-  gd_discard(D);
+#define ENC_SUFFIX ".xz"
+#define ENC_COMPRESS \
+  snprintf(command, 4096, "\"%s\" -f %s > %s", XZ, data, NULL_DEVICE)
 
-  unlink(xzdata);
-  unlink(format);
-  rmdir(filedir);
-
-#ifdef USE_LZMA
-  CHECKI(error, 0);
-#else
-  CHECKI(error, GD_E_UNSUPPORTED);
-#endif
-  CHECKI(n, 0);
-
-  return r;
-#endif
-}
+#include "enc_get_far.c"

--- a/test/lzma_xz_get_get.c
+++ b/test/lzma_xz_get_get.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2014, 2017 D.V. Wiebe
+/* Copyright (C) 2026 G. Smecher
  *
  ***************************************************************************
  *
@@ -20,58 +20,16 @@
  */
 #include "test.h"
 
-int main(void)
-{
-#if !defined USE_LZMA || !defined TEST_LZMA
-  return 77; /* skip test */
-#else
-  const char *filedir = "dirfile";
-  const char *format = "dirfile/format";
-  const char *data = "dirfile/data";
-  const char *xzdata = "dirfile/data.xz";
-  uint16_t c1[8], c2[8];
-  char command[4096];
-  int i, n1, e1, e2, n2, e3, r = 0;
-  DIRFILE *D;
-
-  memset(c1, 0, 16);
-  memset(c2, 0, 16);
-  rmdirfile();
-  mkdir(filedir, 0700);
-
-  MAKEFORMATFILE(format, "data RAW UINT16 8\n");
-  MAKEDATAFILE(data, uint16_t, i, 256);
-
-  /* compress */
-  snprintf(command, 4096, "\"%s\" -f %s > %s", XZ, data, NULL_DEVICE);
-  if (gd_system(command))
-    return 1;
-
-  D = gd_open(filedir, GD_RDONLY | GD_VERBOSE);
-  n1 = gd_getdata(D, "data", 5, 0, 1, 0, GD_UINT16, c1);
-  CHECKI(n1, 8);
-  e1 = gd_error(D);
-  CHECKI(e1, 0);
-
-  e2 = gd_close(D);
-  CHECKI(e2, 0);
-
-  D = gd_open(filedir, GD_RDONLY | GD_VERBOSE);
-  n2 = gd_getdata(D, "data", 5, 0, 1, 0, GD_UINT16, c2);
-  e3 = gd_error(D);
-  CHECKI(e3, 0);
-  CHECKI(n2, 8);
-  for (i = 0; i < 8; ++i) {
-    CHECKIi(i,c1[i], 40 + i);
-    CHECKIi(i,c2[i], 40 + i);
-  }
-
-  gd_discard(D);
-
-  unlink(xzdata);
-  unlink(format);
-  rmdir(filedir);
-
-  return r;
+#ifndef TEST_LZMA
+#define ENC_SKIP_TEST 1
 #endif
-}
+
+#ifdef USE_LZMA
+#define USE_ENC 1
+#endif
+
+#define ENC_SUFFIX ".xz"
+#define ENC_COMPRESS \
+  snprintf(command, 4096, "\"%s\" -f %s > %s", XZ, data, NULL_DEVICE)
+
+#include "enc_get_get.c"

--- a/test/lzma_xz_get_get2.c
+++ b/test/lzma_xz_get_get2.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2014, 2017 D.V. Wiebe
+/* Copyright (C) 2026 G. Smecher
  *
  ***************************************************************************
  *
@@ -20,53 +20,16 @@
  */
 #include "test.h"
 
-int main(void)
-{
-#if !defined USE_LZMA || !defined TEST_LZMA
-  return 77; /* skip test */
-#else
-  const char *filedir = "dirfile";
-  const char *format = "dirfile/format";
-  const char *data = "dirfile/data";
-  const char *xzdata = "dirfile/data.xz";
-  uint16_t c1[8], c2[8];
-  char command[4096];
-  int i, n1, error1, n2, error2, r = 0;
-  DIRFILE *D;
-
-  memset(c1, 0, 16);
-  memset(c2, 0, 16);
-  rmdirfile();
-  mkdir(filedir, 0700);
-
-  MAKEFORMATFILE(format, "data RAW UINT16 8\n");
-  MAKEDATAFILE(data, uint16_t, i, 256);
-
-  /* compress */
-  snprintf(command, 4096, "\"%s\" -f %s > %s", XZ, data, NULL_DEVICE);
-  if (gd_system(command))
-    return 1;
-
-  D = gd_open(filedir, GD_RDONLY | GD_VERBOSE);
-  n1 = gd_getdata(D, "data", 0, 0, 1, 0, GD_UINT16, c1);
-  error1 = gd_error(D);
-  n2 = gd_getdata(D, "data", 0, 0, 1, 0, GD_UINT16, c2);
-  error2 = gd_error(D);
-  gd_discard(D);
-
-  unlink(xzdata);
-  unlink(format);
-  rmdir(filedir);
-
-  CHECKI(error1, 0);
-  CHECKI(error2, 0);
-  CHECKI(n1, 8);
-  CHECKI(n2, 8);
-  for (i = 0; i < 8; ++i) {
-    CHECKUi(i,c1[i], i);
-    CHECKUi(i,c2[i], i);
-  }
-
-  return r;
+#ifndef TEST_LZMA
+#define ENC_SKIP_TEST 1
 #endif
-}
+
+#ifdef USE_LZMA
+#define USE_ENC 1
+#endif
+
+#define ENC_SUFFIX ".xz"
+#define ENC_COMPRESS \
+  snprintf(command, 4096, "\"%s\" -f %s > %s", XZ, data, NULL_DEVICE)
+
+#include "enc_get_get2.c"

--- a/test/lzma_xz_move_to.c
+++ b/test/lzma_xz_move_to.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2014, 2017 D.V. Wiebe
+/* Copyright (C) 2026 G. Smecher
  *
  ***************************************************************************
  *
@@ -20,89 +20,17 @@
  */
 #include "test.h"
 
-int main(void)
-{
-  const char *filedir = "dirfile";
-  const char *format = "dirfile/format";
-  const char *data_xz = "dirfile/data.xz";
-  const char *data_raw = "dirfile/data";
-  uint8_t data_in[256];
-  DIRFILE *D;
-#ifdef USE_LZMA
-  uint8_t d;
-  char command[4096];
-  int i;
-#endif
-  int fd, e1, e2, unlink_raw, r = 0;
-  struct stat buf;
-
-  rmdirfile();
-  mkdir(filedir, 0700); 
-
-  for (fd = 0; fd < 256; ++fd)
-    data_in[fd] = (unsigned char)fd;
-
-  MAKEFORMATFILE(format, "data RAW UINT8 8\n/ENCODING none\n/ENDIAN little\n");
-
-  fd = open(data_raw, O_CREAT | O_EXCL | O_WRONLY | O_BINARY, 0666);
-  write(fd, data_in, 256);
-  close(fd);
-
-#ifdef USE_LZMA
-  D = gd_open(filedir, GD_RDWR | GD_VERBOSE);
-#else
-  D = gd_open(filedir, GD_RDWR);
-#endif
-  gd_alter_encoding(D, GD_LZMA_ENCODED, 0, 1);
-  e1 = gd_error(D);
-
-  e2 = gd_close(D);
-  CHECKI(e2, 0);
-
-#ifdef USE_LZMA
-  if (stat(data_xz, &buf)) {
-    perror("stat");
-    r = 1;
-  }
-  CHECKI(stat(data_raw, &buf), -1);
-#else
-  if (stat(data_raw, &buf)) {
-    perror("stat");
-    r = 1;
-  }
-  CHECKI(stat(data_xz, &buf), -1);
+#ifndef TEST_LZMA
+#define ENC_SKIP_TEST 1
 #endif
 
 #ifdef USE_LZMA
-  /* uncompress */
-  snprintf(command, 4096, "\"%s\" --decompress -f %s > %s", XZ, data_xz, NULL_DEVICE);
-  if (gd_system(command)) {
-    fprintf(stderr, "command failed: %s\n", command);
-    r = 1;
-  } else {
-    fd = open(data_raw, O_RDONLY | O_BINARY);
-    if (fd >= 0) {
-      i = 0;
-      while (read(fd, &d, sizeof(uint8_t))) {
-        CHECKIi(i, d, i);
-        i++;
-      }
-      CHECKI(i, 256);
-      close(fd);
-    }
-  }
+#define USE_ENC 1
 #endif
 
-  unlink_raw = unlink(data_raw);
-  unlink(format);
-  rmdir(filedir);
+#define ENC_SUFFIX ".xz"
+#define ENC_ENCODING GD_LZMA_ENCODED
+#define ENC_COMPRESS \
+  snprintf(command, 4096, "\"%s\" --decompress -f %s > %s", XZ, encdata, NULL_DEVICE)
 
-  CHECKI(unlink_raw, 0);
-#ifdef USE_LZMA
-  CHECKI(e1, GD_E_OK);
-#else
-  CHECKI(e1, GD_E_UNSUPPORTED);
-#endif
-
-  return r;
-}
+#include "enc_move_to.c"

--- a/test/lzma_xz_put.c
+++ b/test/lzma_xz_put.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2014, 2017 D.V. Wiebe
+/* Copyright (C) 2026 G. Smecher
  *
  ***************************************************************************
  *
@@ -20,92 +20,17 @@
  */
 #include "test.h"
 
-int main(void)
-{
 #ifndef TEST_LZMA
-  return 77;
-#else
-  const char *filedir = "dirfile";
-  const char *format = "dirfile/format";
-  const char *data_xz = "dirfile/data.xz";
-  const char *data = "dirfile/data";
-  uint8_t c[8];
-#ifdef USE_LZMA
-  char command[4096];
-  uint8_t d;
-#endif
-  struct stat buf;
-  int fd, i, n, e1, e2, stat_data, unlink_data, unlink_xz, r = 0;
-  DIRFILE *D;
-
-  rmdirfile();
-  mkdir(filedir, 0700);
-
-  for (i = 0; i < 8; ++i)
-    c[i] = (uint8_t)(40 + i);
-
-  MAKEFORMATFILE(format, "data RAW UINT8 8\n");
-
-#ifdef USE_LZMA
-  D = gd_open(filedir, GD_RDWR | GD_LZMA_ENCODED | GD_VERBOSE);
-#else
-  D = gd_open(filedir, GD_RDWR | GD_LZMA_ENCODED);
-#endif
-  n = gd_putdata(D, "data", 5, 0, 1, 0, GD_UINT8, c);
-  e1 = gd_error(D);
-
-  e2 = gd_close(D);
-  CHECKI(e2, 0);
-
-  stat_data = stat(data_xz, &buf);
-#ifdef USE_LZMA
-  if (stat_data) {
-    perror("stat");
-  }
-  CHECKI(stat_data, 0);
-#else
-  CHECKI(stat_data, -1);
+#define ENC_SKIP_TEST 1
 #endif
 
 #ifdef USE_LZMA
-  /* uncompress */
-  snprintf(command, 4096, "\"%s\" --decompress -f %s > %s", XZ, data_xz, NULL_DEVICE);
-  if (gd_system(command)) {
-    r = 1;
-  } else {
-    fd = open(data, O_RDONLY | O_BINARY);
-    if (fd >= 0) {
-      i = 0;
-      while (read(fd, &d, sizeof(uint8_t))) {
-        if (i < 40 || i > 48) {
-          CHECKIi(i, d, 0);
-        } else
-          CHECKIi(i, d, i);
-        i++;
-      }
-      CHECKI(i, 48);
-      close(fd);
-    }
-  }
+#define USE_ENC 1
 #endif
 
-  unlink_xz = unlink(data_xz);
-  CHECKI(unlink_xz, -1);
+#define ENC_SUFFIX ".xz"
+#define ENC_ENCODING GD_LZMA_ENCODED
+#define ENC_COMPRESS \
+  snprintf(command, 4096, "\"%s\" --decompress -f %s > %s", XZ, encdata, NULL_DEVICE)
 
-  unlink_data = unlink(data);
-  unlink(format);
-  rmdir(filedir);
-
-#ifdef USE_LZMA
-  CHECKI(unlink_data, 0);
-  CHECKI(e1, GD_E_OK);
-  CHECKI(n, 8);
-#else
-  CHECKI(unlink_data, -1);
-  CHECKI(e1, GD_E_UNSUPPORTED);
-  CHECKI(n, 0);
-#endif
-
-  return r;
-#endif
-}
+#include "enc_put.c"

--- a/test/lzma_xz_put_back.c
+++ b/test/lzma_xz_put_back.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2014, 2017 D.V. Wiebe
+/* Copyright (C) 2026 G. Smecher
  *
  ***************************************************************************
  *
@@ -20,78 +20,17 @@
  */
 #include "test.h"
 
-int main(void)
-{
-#if ! (defined TEST_LZMA) || ! (defined USE_LZMA)
-  return 77;
-#else
-  const char *filedir = "dirfile";
-  const char *format = "dirfile/format";
-  const char *data_xz = "dirfile/data.xz";
-  const char *data = "dirfile/data";
-  uint8_t c[8];
-  char command[4096];
-  uint8_t d;
-  struct stat buf;
-  int fd, i, n1, n2, e1, e2, e3, stat_data, unlink_data, r = 0;
-  DIRFILE *D;
-
-  rmdirfile();
-  mkdir(filedir, 0700);
-
-  for (i = 0; i < 8; ++i)
-    c[i] = (uint8_t)(40 + i);
-
-  MAKEFORMATFILE(format, "data RAW UINT8 8\n");
-
-  D = gd_open(filedir, GD_RDWR | GD_LZMA_ENCODED | GD_VERBOSE);
-  n1 = gd_putdata(D, "data", 5, 0, 1, 0, GD_UINT8, c);
-  e1 = gd_error(D);
-  CHECKI(e1, GD_E_OK);
-  CHECKI(n1, 8);
-
-  n2 = gd_putdata(D, "data", 0, 0, 1, 0, GD_UINT8, c);
-  e2 = gd_error(D);
-  CHECKI(e2, GD_E_OK);
-  CHECKI(n2, 8);
-
-  e3 = gd_close(D);
-  CHECKI(e3, 0);
-
-  stat_data = stat(data_xz, &buf);
-  if (stat_data) {
-    perror("stat");
-  }
-  CHECKI(stat_data, 0);
-
-  /* uncompress */
-  snprintf(command, 4096, "\"%s\" --decompress -f %s > %s", XZ, data_xz, NULL_DEVICE);
-  if (gd_system(command)) {
-    r = 1;
-  } else {
-    fd = open(data, O_RDONLY | O_BINARY);
-    if (fd >= 0) {
-      i = 0;
-      while (read(fd, &d, sizeof(uint8_t))) {
-        if (i < 8) {
-          CHECKIi(i, d, i + 40);
-        } else if (i < 40 || i > 48) {
-          CHECKIi(i, d, 0);
-        } else
-          CHECKIi(i, d, i);
-        i++;
-      }
-      CHECKI(i, 48);
-      close(fd);
-    }
-  }
-
-  unlink_data = unlink(data);
-  unlink(format);
-  rmdir(filedir);
-
-  CHECKI(unlink_data, 0);
-
-  return r;
+#ifndef TEST_LZMA
+#define ENC_SKIP_TEST 1
 #endif
-}
+
+#ifdef USE_LZMA
+#define USE_ENC 1
+#endif
+
+#define ENC_SUFFIX ".xz"
+#define ENC_ENCODING GD_LZMA_ENCODED
+#define ENC_COMPRESS \
+  snprintf(command, 4096, "\"%s\" --decompress -f %s > %s", XZ, encdata, NULL_DEVICE)
+
+#include "enc_put_back.c"

--- a/test/lzma_xz_put_endian.c
+++ b/test/lzma_xz_put_endian.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2014, 2017 D.V. Wiebe
+/* Copyright (C) 2026 G. Smecher
  *
  ***************************************************************************
  *
@@ -20,95 +20,17 @@
  */
 #include "test.h"
 
-#ifdef WORDS_BIGENDIAN
-#define ENDIAN "ENDIAN little"
-#else
-#define ENDIAN "ENDIAN big"
-#endif
-
-int main(void)
-{
 #ifndef TEST_LZMA
-  return 77;
-#else
-  const char *filedir = "dirfile";
-  const char *format = "dirfile/format";
-  const char *data_xz = "dirfile/data.xz";
-  const char *data = "dirfile/data";
-  uint16_t c[8];
-#ifdef USE_LZMA
-  char command[4096];
-  uint16_t d;
-#endif
-  struct stat buf;
-  int fd, i, n, e1, e2, stat_data, unlink_data, r = 0;
-  DIRFILE *D;
-
-  rmdirfile();
-  mkdir(filedir, 0700);
-
-  for (i = 0; i < 8; ++i)
-    c[i] = (uint16_t)(0x102 * i);
-
-  MAKEFORMATFILE(format, "data RAW UINT16 8\n" ENDIAN "\n");
-
-#ifdef USE_LZMA
-  D = gd_open(filedir, GD_RDWR | GD_LZMA_ENCODED | GD_VERBOSE);
-#else
-  D = gd_open(filedir, GD_RDWR | GD_LZMA_ENCODED);
-#endif
-  n = gd_putdata(D, "data", 5, 0, 1, 0, GD_UINT16, c);
-  e1 = gd_error(D);
-
-  e2 = gd_close(D);
-  CHECKI(e2, 0);
-
-  stat_data = stat(data_xz, &buf);
-#ifdef USE_LZMA
-  if (stat_data) {
-    perror("stat");
-  }
-  CHECKI(stat_data, 0);
-#else
-  CHECKI(stat_data, -1);
+#define ENC_SKIP_TEST 1
 #endif
 
 #ifdef USE_LZMA
-  /* uncompress */
-  snprintf(command, 4096, "\"%s\" --decompress -f %s > %s", XZ, data_xz, NULL_DEVICE);
-  if (gd_system(command)) {
-    r = 1;
-  } else {
-    fd = open(data, O_RDONLY | O_BINARY);
-    if (fd >= 0) {
-      i = 0;
-      while (read(fd, &d, sizeof(uint16_t))) {
-        if (i < 40 || i > 48) {
-          CHECKIi(i, d, 0);
-        } else
-          CHECKIi(i, d, 0x201 * (i - 40));
-        i++;
-      }
-      CHECKI(i, 48);
-      close(fd);
-    }
-  }
+#define USE_ENC 1
 #endif
 
-  unlink_data = unlink(data);
-  unlink(format);
-  rmdir(filedir);
+#define ENC_SUFFIX ".xz"
+#define ENC_ENCODING GD_LZMA_ENCODED
+#define ENC_COMPRESS \
+  snprintf(command, 4096, "\"%s\" --decompress -f %s > %s", XZ, encdata, NULL_DEVICE)
 
-#ifdef USE_LZMA
-  CHECKI(unlink_data, 0);
-  CHECKI(e1, GD_E_OK);
-  CHECKI(n, 8);
-#else
-  CHECKI(unlink_data, -1);
-  CHECKI(e1, GD_E_UNSUPPORTED);
-  CHECKI(n, 0);
-#endif
-
-  return r;
-#endif
-}
+#include "enc_put_endian.c"

--- a/test/lzma_xz_put_nframes.c
+++ b/test/lzma_xz_put_nframes.c
@@ -20,10 +20,6 @@
  */
 #include "test.h"
 
-#ifndef TEST_LZMA
-#define ENC_SKIP_TEST 1
-#endif
-
 #ifdef USE_LZMA
 #define USE_ENC 1
 #endif
@@ -31,4 +27,4 @@
 #define ENC_SUFFIX ".xz"
 #define ENC_ENCODING GD_LZMA_ENCODED
 
-#include "enc_put_get.c"
+#include "enc_put_nframes.c"

--- a/test/lzma_xz_put_pad.c
+++ b/test/lzma_xz_put_pad.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2014, 2017 D.V. Wiebe
+/* Copyright (C) 2026 G. Smecher
  *
  ***************************************************************************
  *
@@ -20,80 +20,17 @@
  */
 #include "test.h"
 
-int main(void)
-{
-#if ! (defined TEST_LZMA) || ! (defined USE_LZMA)
-  return 77;
-#else
-  const char *filedir = "dirfile";
-  const char *format = "dirfile/format";
-  const char *data_xz = "dirfile/data.xz";
-  const char *data = "dirfile/data";
-  uint8_t c[8];
-  char command[4096];
-  uint8_t d;
-  struct stat buf;
-  int fd, i, n1, n2, e1, e2, e3, stat_data, unlink_data, r = 0;
-  DIRFILE *D;
-
-  rmdirfile();
-  mkdir(filedir, 0700);
-
-  for (i = 0; i < 8; ++i)
-    c[i] = (uint8_t)(40 + i);
-
-  MAKEFORMATFILE(format, "data RAW UINT8 8\n");
-
-  D = gd_open(filedir, GD_RDWR | GD_LZMA_ENCODED | GD_VERBOSE);
-  n1 = gd_putdata(D, "data", 0, 0, 1, 0, GD_UINT8, c);
-  e1 = gd_error(D);
-  CHECKI(e1, GD_E_OK);
-  CHECKI(n1, 8);
-  gd_close(D);
-
-  D = gd_open(filedir, GD_RDWR | GD_LZMA_ENCODED | GD_VERBOSE);
-  n2 = gd_putdata(D, "data", 5, 0, 1, 0, GD_UINT8, c);
-  e2 = gd_error(D);
-  CHECKI(e2, GD_E_OK);
-  CHECKI(n2, 8);
-
-  e3 = gd_close(D);
-  CHECKI(e3, 0);
-
-  stat_data = stat(data_xz, &buf);
-  if (stat_data) {
-    perror("stat");
-  }
-  CHECKI(stat_data, 0);
-
-  /* uncompress */
-  snprintf(command, 4096, "\"%s\" --decompress -f %s > %s", XZ, data_xz, NULL_DEVICE);
-  if (gd_system(command)) {
-    r = 1;
-  } else {
-    fd = open(data, O_RDONLY | O_BINARY);
-    if (fd >= 0) {
-      i = 0;
-      while (read(fd, &d, sizeof(uint8_t))) {
-        if (i < 8) {
-          CHECKIi(i, d, i + 40);
-        } else if (i < 40 || i > 48) {
-          CHECKIi(i, d, 0);
-        } else
-          CHECKIi(i, d, i);
-        i++;
-      }
-      CHECKI(i, 48);
-      close(fd);
-    }
-  }
-
-  unlink_data = unlink(data);
-  unlink(format);
-  rmdir(filedir);
-
-  CHECKI(unlink_data, 0);
-
-  return r;
+#ifndef TEST_LZMA
+#define ENC_SKIP_TEST 1
 #endif
-}
+
+#ifdef USE_LZMA
+#define USE_ENC 1
+#endif
+
+#define ENC_SUFFIX ".xz"
+#define ENC_ENCODING GD_LZMA_ENCODED
+#define ENC_COMPRESS \
+  snprintf(command, 4096, "\"%s\" --decompress -f %s > %s", XZ, encdata, NULL_DEVICE)
+
+#include "enc_put_pad.c"

--- a/test/lzma_xz_sync.c
+++ b/test/lzma_xz_sync.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2014, 2017 D.V. Wiebe
+/* Copyright (C) 2026 G. Smecher
  *
  ***************************************************************************
  *
@@ -20,70 +20,17 @@
  */
 #include "test.h"
 
-int main(void)
-{
-#if !defined TEST_LZMA || !defined USE_LZMA
-  return 77;
-#else
-  const char *filedir = "dirfile";
-  const char *format = "dirfile/format";
-  const char *data_xz = "dirfile/data.xz";
-  const char *data = "dirfile/data";
-  uint8_t c[8];
-  char command[4096];
-  uint8_t d;
-  struct stat buf;
-  int fd, i, n, e1, e2, stat_data, r = 0;
-  DIRFILE *D;
-
-  rmdirfile();
-  mkdir(filedir, 0700);
-
-  for (i = 0; i < 8; ++i)
-    c[i] = (uint8_t)(40 + i);
-
-  MAKEFORMATFILE(format, "data RAW UINT8 8\n");
-
-  D = gd_open(filedir, GD_RDWR | GD_LZMA_ENCODED | GD_VERBOSE);
-  gd_putdata(D, "data", 5, 0, 1, 0, GD_UINT8, c);
-  n = gd_flush(D, "data");
-  e1 = gd_error(D);
-  CHECKI(e1, GD_E_OK);
-  CHECKI(n, 0);
-
-  e2 = gd_close(D);
-  CHECKI(e2, 0);
-
-  stat_data = stat(data_xz, &buf);
-  if (stat_data) {
-    perror("stat");
-  }
-  CHECKI(stat_data, 0);
-
-  /* uncompress */
-  snprintf(command, 4096, "\"%s\" --decompress -f %s > %s", XZ, data_xz, NULL_DEVICE);
-  if (gd_system(command)) {
-    r = 1;
-  } else {
-    fd = open(data, O_RDONLY | O_BINARY);
-    if (fd >= 0) {
-      i = 0;
-      while (read(fd, &d, sizeof(uint8_t))) {
-        if (i < 40 || i > 48) {
-          CHECKIi(i, d, 0);
-        } else
-          CHECKIi(i, d, i);
-        i++;
-      }
-      CHECKI(i, 48);
-      close(fd);
-    }
-  }
-
-  unlink(data);
-  unlink(format);
-  rmdir(filedir);
-
-  return r;
+#ifndef TEST_LZMA
+#define ENC_SKIP_TEST 1
 #endif
-}
+
+#ifdef USE_LZMA
+#define USE_ENC 1
+#endif
+
+#define ENC_SUFFIX ".xz"
+#define ENC_ENCODING GD_LZMA_ENCODED
+#define ENC_COMPRESS \
+  snprintf(command, 4096, "\"%s\" --decompress -f %s > %s", XZ, encdata, NULL_DEVICE)
+
+#include "enc_sync.c"


### PR DESCRIPTION
This PR expands the fuzzer's "TestSparseWriteModel" test case over all writable encodings (formerly, only the RAW encoding was tested).

As a result of this expansion, three problems were identified:
1. the LZMA encoding had a missing bookkeeping issue causing double-finalization and a marked-dirty dirfile,
2. the ASCII encoding did not correctly handle non-append rewrites
3. as a result of (1) and (2), some gaps in unit-test coverage were identified and fixed.