### PR TITLE
Fix for cmake check_include_file

### DIFF
--- a/cmake/CMakeLists.txt
+++ b/cmake/CMakeLists.txt
@@ -183,7 +183,6 @@ endif()
 set(DEFINE_GD_GETDATA_INT_VERSION "#define GD_GETDATA_INT_VERSION ${GETDATA_INT_VERSION}")
 
 # Platform-independent configuration checks
-include(CheckIncludeFile)
 include(CheckSymbolExists)
 include(CheckTypeSize)
 include(CheckFunctionExists)

--- a/cmake/CMakeLists.txt
+++ b/cmake/CMakeLists.txt
@@ -98,8 +98,9 @@ find_program(UNZIP unzip)
 find_program(XZ xz)
 find_program(ZIP zip)
 
+include(CheckIncludeFile)
+
 if(BZIP2_FOUND)
-  include(CheckIncludeFile)
   set(CMAKE_REQUIRED_INCLUDES ${BZIP2_INCLUDE_DIRS})
   check_include_file(bzlib.h HAVE_BZLIB_H)
   unset(CMAKE_REQUIRED_INCLUDES)


### PR DESCRIPTION
When testing cmake, I found this issue where if bzip2 dev files aren't installed, then `check_include_file` will fail in some later uses, since its `include` is conditional.

This fix solved the problem for me. But I don't know much about `cmake` so am open to suggestions.